### PR TITLE
ci: switch sync-dev to workflow_dispatch with write permission

### DIFF
--- a/.github/workflows/sync-dev.yml
+++ b/.github/workflows/sync-dev.yml
@@ -1,16 +1,14 @@
 name: Sync dev to main
 
 on:
-  workflow_run:
-    workflows: ["CI"]
-    branches: [main]
-    types: [completed]
+  workflow_dispatch:
 
 jobs:
   sync:
     name: Reset dev to main
     runs-on: ubuntu-latest
-    if: github.event.workflow_run.conclusion == 'success'
+    permissions:
+      contents: write
     steps:
       - uses: actions/checkout@v4
         with:


### PR DESCRIPTION
## Summary

- Replaces the broken `workflow_run` trigger (which never fired because CI doesn't run on `main` pushes) with `workflow_dispatch` — run it manually after each ship
- Adds `permissions: contents: write` so the force-push step can actually write to the `dev` branch (fixes the 403 error)
- Prevents hotfixes to `main` from accidentally wiping in-progress work on `dev`