### PR TITLE
Refactor new-hire mode to sit above engine

### DIFF
--- a/app/components/dashboard/NewHireModeBanner.vue
+++ b/app/components/dashboard/NewHireModeBanner.vue
@@ -7,14 +7,16 @@ const userStore = useUserStore()
 </script>
 
 <template>
-  <!-- Mode OFF: show "not found" warning with toggle -->
+  <!-- Mode OFF: show "not found" / "no emp number" warning with toggle -->
   <UAlert
-    v-if="!newHireMode.isActive.value"
+    v-if="!newHireMode.enabled.value"
     icon="i-lucide-alert-triangle"
     color="warning"
     variant="subtle"
-    title="Employee Number Not Found"
-    :description="`Employee number '${userStore.profile?.employee_number}' was not found in the current seniority list.`"
+    :title="userStore.profile?.employee_number ? 'Employee Number Not Found' : 'No Employee Number Set'"
+    :description="userStore.profile?.employee_number
+      ? `Employee number '${userStore.profile.employee_number}' was not found in the current seniority list.`
+      : 'Enable New Hire Mode to see projected seniority data as a new hire at the bottom of the list.'"
   >
     <template #actions>
       <div class="flex items-center gap-2">

--- a/app/components/dashboard/tabs/DemographicsTab.vue
+++ b/app/components/dashboard/tabs/DemographicsTab.vue
@@ -1,13 +1,23 @@
 <script setup lang="ts">
 import { useQualDemographics } from '~/composables/useQualDemographics'
+import { useNewHireMode } from '~/composables/useNewHireMode'
 import { computeYOS } from '#shared/utils/qual-analytics'
 
 const demographics = useQualDemographics()
+const newHireMode = useNewHireMode()
 
 const userYos = computed(() => {
+  const synthetic = newHireMode.syntheticEntry.value
+  if (synthetic) return computeYOS(synthetic.hire_date)
   const entry = demographics.userEntry.value
-  return entry ? computeYOS(entry.hire_date) : undefined
+  if (entry) return computeYOS(entry.hire_date)
+  return undefined
 })
+
+const userSeniorityNumber = computed(() =>
+  newHireMode.syntheticEntry.value?.seniority_number
+  ?? demographics.userEntry.value?.seniority_number,
+)
 </script>
 
 <template>
@@ -23,7 +33,7 @@ const userYos = computed(() => {
           </template>
           <AnalyticsJuniorCaptainTable
             :rows="demographics.mostJuniorCAs.value"
-            :user-seniority-number="demographics.userEntry.value?.seniority_number"
+            :user-seniority-number="userSeniorityNumber"
           />
         </UCard>
       </div>

--- a/app/components/dashboard/tabs/MyStatusTab.vue
+++ b/app/components/dashboard/tabs/MyStatusTab.vue
@@ -39,7 +39,7 @@ defineProps<{
       <!-- Banners (outside grid) -->
       <DashboardEmployeeNumberBanner v-if="!hasEmployeeNumber" class="mb-4 lg:mb-6" />
       <DashboardNewHireModeBanner
-        v-else-if="!userFound || isNewHireMode"
+        v-if="!userFound || isNewHireMode"
         class="mb-4 lg:mb-6"
       />
 

--- a/app/components/dashboard/tabs/PositionTab.vue
+++ b/app/components/dashboard/tabs/PositionTab.vue
@@ -1,11 +1,13 @@
 <script setup lang="ts">
 import { useQualProjections } from '~/composables/useQualProjections'
+import { useNewHireMode } from '~/composables/useNewHireMode'
 import { useUserStore } from '~/stores/user'
 import { DEFAULT_GROWTH_CONFIG } from '#shared/types/growth-config'
 import type { GrowthConfig } from '#shared/types/growth-config'
 
 const userStore = useUserStore()
-const hasEmployeeNumber = computed(() => !!userStore.profile?.employee_number)
+const newHireMode = useNewHireMode()
+const hasEmployeeNumber = computed(() => !!userStore.profile?.employee_number || !!newHireMode.syntheticEntry.value)
 
 const growthConfig = ref<GrowthConfig>({ ...DEFAULT_GROWTH_CONFIG })
 const projections = useQualProjections(undefined, growthConfig)

--- a/app/components/dashboard/tabs/RetirementsTab.vue
+++ b/app/components/dashboard/tabs/RetirementsTab.vue
@@ -2,17 +2,19 @@
 import { useQualDemographics } from '~/composables/useQualDemographics'
 import { useQualProjections } from '~/composables/useQualProjections'
 import { useUserTrajectory } from '~/composables/useUserTrajectory'
+import { useNewHireMode } from '~/composables/useNewHireMode'
 import { useUserStore } from '~/stores/user'
 import { useSeniorityStore } from '~/stores/seniority'
 
 const userStore = useUserStore()
 const seniorityStore = useSeniorityStore()
+const newHireMode = useNewHireMode()
 const demographics = useQualDemographics()
 const projections = useQualProjections(demographics.qualSpec)
 const { computeRetirementProjection } = useUserTrajectory()
 const entries = computed(() => seniorityStore.entries)
 
-const hasEmployeeNumber = computed(() => !!userStore.profile?.employee_number)
+const hasEmployeeNumber = computed(() => !!userStore.profile?.employee_number || !!newHireMode.syntheticEntry.value)
 
 </script>
 

--- a/app/components/dashboard/tabs/TrajectoryTab.vue
+++ b/app/components/dashboard/tabs/TrajectoryTab.vue
@@ -3,6 +3,7 @@ import { useQualDemographics } from '~/composables/useQualDemographics'
 import { useQualProjections } from '~/composables/useQualProjections'
 import { useUserTrajectory } from '~/composables/useUserTrajectory'
 import { useDashboardStats } from '~/composables/useDashboardStats'
+import { useNewHireMode } from '~/composables/useNewHireMode'
 import { useUserStore } from '~/stores/user'
 import { useSeniorityStore } from '~/stores/seniority'
 import { DEFAULT_GROWTH_CONFIG } from '#shared/types/growth-config'
@@ -10,7 +11,8 @@ import type { GrowthConfig } from '#shared/types/growth-config'
 
 const userStore = useUserStore()
 const seniorityStore = useSeniorityStore()
-const hasEmployeeNumber = computed(() => !!userStore.profile?.employee_number)
+const newHireMode = useNewHireMode()
+const hasEmployeeNumber = computed(() => !!userStore.profile?.employee_number || !!newHireMode.syntheticEntry.value)
 
 const growthConfig = ref<GrowthConfig>({ ...DEFAULT_GROWTH_CONFIG })
 

--- a/app/components/settings/SettingsNewHireModeCard.vue
+++ b/app/components/settings/SettingsNewHireModeCard.vue
@@ -1,0 +1,88 @@
+<script setup lang="ts">
+import { useNewHireMode } from '~/composables/useNewHireMode'
+
+const newHireMode = useNewHireMode()
+</script>
+
+<template>
+  <UCard>
+    <template #header>
+      <div class="flex items-center justify-between">
+        <div>
+          <h2 class="text-lg font-semibold">New Hire Mode</h2>
+          <p class="text-sm text-muted mt-0.5">Preview your projected seniority as a new hire.</p>
+        </div>
+        <USwitch v-model="newHireMode.enabled.value" :disabled="newHireMode.realUserFound.value" />
+      </div>
+    </template>
+
+    <div v-if="newHireMode.realUserFound.value && !newHireMode.enabled.value" class="text-sm text-muted">
+      Your employee number was found in the seniority list. New Hire Mode is only available when you are not on the list.
+    </div>
+
+    <div v-else-if="newHireMode.enabled.value" class="space-y-4">
+      <UAlert
+        v-if="!newHireMode.isConfigured.value"
+        icon="i-lucide-info"
+        color="warning"
+        variant="subtle"
+        title="Configuration required"
+        description="Set your base, seat, fleet, and birth date to activate new hire projections."
+      />
+
+      <div class="grid grid-cols-2 gap-4">
+        <UFormField label="Base" name="base">
+          <USelectMenu
+            v-model="newHireMode.selectedBase.value"
+            :items="newHireMode.availableBases.value"
+            placeholder="Select base..."
+            class="w-full"
+            :search-input="false"
+            clear
+          />
+        </UFormField>
+
+        <UFormField label="Seat" name="seat">
+          <USelectMenu
+            v-model="newHireMode.selectedSeat.value"
+            :items="newHireMode.availableSeats.value"
+            placeholder="Select seat..."
+            class="w-full"
+            :search-input="false"
+            clear
+          />
+        </UFormField>
+
+        <UFormField label="Fleet" name="fleet">
+          <USelectMenu
+            v-model="newHireMode.selectedFleet.value"
+            :items="newHireMode.availableFleets.value"
+            placeholder="Select fleet..."
+            class="w-full"
+            :search-input="false"
+            clear
+          />
+        </UFormField>
+
+        <UFormField label="Birth Date" name="birthDate" :hint="newHireMode.retireDate.value ? `Retires ${newHireMode.retireDate.value}` : undefined">
+          <UInput
+            :model-value="newHireMode.birthDate.value ?? undefined"
+            type="date"
+            class="w-full"
+            @update:model-value="newHireMode.birthDate.value = $event || null"
+          />
+        </UFormField>
+      </div>
+
+      <div class="flex justify-end pt-2 border-t border-default">
+        <UButton color="neutral" variant="ghost" icon="i-lucide-x" @click="newHireMode.reset()">
+          Clear and disable
+        </UButton>
+      </div>
+    </div>
+
+    <p v-else class="text-sm text-muted">
+      Enable to simulate your standing as a new hire at the bottom of the seniority list.
+    </p>
+  </UCard>
+</template>

--- a/app/composables/useCompanyStats.ts
+++ b/app/composables/useCompanyStats.ts
@@ -1,6 +1,8 @@
 import type { SeniorityEntryResponse } from '#shared/schemas/seniority-list'
 import { formatDateLabel } from '#shared/utils/seniority-math'
 import { useSeniorityStore } from '~/stores/seniority'
+// Intentionally uses the base engine — company aggregates should not include
+// the synthetic new-hire entry.
 import { useSeniorityEngine } from './useSeniorityEngine'
 
 type SeniorityEntry = SeniorityEntryResponse

--- a/app/composables/useDashboardStats.test.ts
+++ b/app/composables/useDashboardStats.test.ts
@@ -31,7 +31,6 @@ const mockNewHireMode = vi.hoisted(() => ({
   availableSeats: { value: [] as string[] },
   availableFleets: { value: [] as string[] },
   realUserFound: { value: false },
-  isActive: { value: false },
   syntheticEntry: { value: null as import('../../shared/schemas/seniority-list').SeniorityEntry | null },
 }))
 
@@ -58,7 +57,6 @@ describe('useDashboardStats composable', () => {
     mockSeniorityStore.lists = []
     mockUserStore.profile = null
     mockNewHireMode.enabled.value = false
-    mockNewHireMode.isActive.value = false
     mockNewHireMode.syntheticEntry.value = null
     mockNewHireMode.realUserFound.value = false
   })
@@ -252,15 +250,15 @@ describe('useDashboardStats composable', () => {
       mockSeniorityStore.entries = [
         makeEntry({ seniority_number: 1, employee_number: '100' }),
       ]
-      mockNewHireMode.isActive.value = true
+      mockNewHireMode.enabled.value = true
       mockNewHireMode.syntheticEntry.value = makeDomainEntry({
         seniority_number: 2,
-        employee_number: '999',
+        employee_number: '_new_hire',
         name: 'You (New Hire)',
         base: 'JFK',
         seat: 'CA',
         fleet: '737',
-        retire_date: undefined,
+        retire_date: '2091-06-15',
       })
 
       const { userFound, isNewHireMode } = useDashboardStats()
@@ -274,15 +272,15 @@ describe('useDashboardStats composable', () => {
         makeEntry({ seniority_number: 1, employee_number: '100' }),
         makeEntry({ seniority_number: 2, employee_number: '200' }),
       ]
-      mockNewHireMode.isActive.value = true
+      mockNewHireMode.enabled.value = true
       mockNewHireMode.syntheticEntry.value = makeDomainEntry({
         seniority_number: 3,
-        employee_number: '999',
+        employee_number: '_new_hire',
         name: 'You (New Hire)',
         base: 'LAX',
         seat: 'FO',
         fleet: '777',
-        retire_date: undefined,
+        retire_date: '2091-06-15',
       })
 
       const { rankCard } = useDashboardStats()
@@ -292,14 +290,11 @@ describe('useDashboardStats composable', () => {
       expect(rankCard.value.fleet).toBe('777')
     })
 
-    it('prefers real entry over synthetic when user IS found', () => {
+    it('uses real entry when new hire mode is off', () => {
       mockUserStore.profile = makeProfile({ employee_number: '100' })
       mockSeniorityStore.entries = [
         makeEntry({ seniority_number: 1, employee_number: '100', base: 'JFK' }),
       ]
-      // Even if new hire mode is technically enabled, isActive should be false
-      // because realUserFound is true — but let's test that the real entry wins
-      mockNewHireMode.isActive.value = false
       mockNewHireMode.syntheticEntry.value = null
 
       const { rankCard, userFound } = useDashboardStats()

--- a/app/composables/useDashboardStats.ts
+++ b/app/composables/useDashboardStats.ts
@@ -4,7 +4,7 @@ import type { QualSpec } from '#shared/utils/seniority-engine'
 import { useSeniorityStore } from '~/stores/seniority'
 import { useUserStore } from '~/stores/user'
 import { useNewHireMode } from './useNewHireMode'
-import { useSeniorityEngine } from './useSeniorityEngine'
+import { useEffectiveSeniorityEngine } from './useEffectiveSeniorityEngine'
 import { useCompanyStats } from './useCompanyStats'
 
 interface StatCard {
@@ -19,17 +19,17 @@ export function useDashboardStats() {
   const seniorityStore = useSeniorityStore()
   const userStore = useUserStore()
   const newHireMode = useNewHireMode()
-  const { snapshot, lens } = useSeniorityEngine()
+  const { snapshot, lens } = useEffectiveSeniorityEngine()
 
-  // Look up user entry from snapshot (includes synthetic entry in new-hire mode)
+  // The effective engine handles the mode switch: in new-hire mode the snapshot
+  // includes the synthetic entry and the lens is anchored to it.
   const userEntry = computed(() => {
-    const empNum = userStore.profile?.employee_number
-    if (!empNum) return undefined
-    return snapshot.value?.byEmployeeNumber.get(empNum)
+    if (!snapshot.value || !lens.value?.anchor) return undefined
+    return snapshot.value.byEmployeeNumber.get(lens.value.anchor.employeeNumber)
   })
 
   const hasData = computed(() => seniorityStore.entries.length > 0)
-  const hasEmployeeNumber = computed(() => !!userStore.profile?.employee_number)
+  const hasEmployeeNumber = computed(() => !!userStore.profile?.employee_number || !!newHireMode.syntheticEntry.value)
   const userFound = computed(() => !!userEntry.value)
 
   const standingResult = computed(() => lens.value?.standing() ?? null)
@@ -166,7 +166,7 @@ export function useDashboardStats() {
     hasData,
     hasEmployeeNumber,
     userFound,
-    isNewHireMode: newHireMode.isActive,
+    isNewHireMode: newHireMode.enabled,
     newHireMode,
     rankCard,
     stats,

--- a/app/composables/useEffectiveSeniorityEngine.test.ts
+++ b/app/composables/useEffectiveSeniorityEngine.test.ts
@@ -1,0 +1,74 @@
+import { describe, it, expect, vi } from 'vitest'
+import { useEffectiveSeniorityEngine } from './useEffectiveSeniorityEngine'
+
+const mockStore = vi.hoisted(() => ({ entries: [] as any[] }))
+const mockUserStore = vi.hoisted(() => ({ profile: null as any }))
+const mockNewHireMode = vi.hoisted(() => ({
+  syntheticEntry: { value: null as any },
+}))
+
+vi.mock('~/stores/seniority', () => ({
+  useSeniorityStore: () => mockStore,
+}))
+vi.mock('~/stores/user', () => ({
+  useUserStore: () => mockUserStore,
+}))
+vi.mock('./useNewHireMode', () => ({
+  useNewHireMode: () => mockNewHireMode,
+}))
+
+const { makeEntry, makeDomainEntry } = await import('#shared/test-utils/factories')
+
+describe('useEffectiveSeniorityEngine', () => {
+  it('delegates to base engine when new hire mode is inactive', () => {
+    mockStore.entries = [makeEntry({ seniority_number: 1, employee_number: 'E1' })]
+    mockUserStore.profile = { employee_number: 'E1' }
+    mockNewHireMode.syntheticEntry.value = null
+
+    const { snapshot, lens } = useEffectiveSeniorityEngine()
+    expect(snapshot.value).not.toBeNull()
+    expect(snapshot.value!.entries).toHaveLength(1)
+    expect(lens.value).not.toBeNull()
+    expect(lens.value!.anchor!.employeeNumber).toBe('E1')
+  })
+
+  it('injects synthetic entry when new hire mode is active', () => {
+    mockStore.entries = [makeEntry({ seniority_number: 1, employee_number: 'E1' })]
+    mockUserStore.profile = null
+    mockNewHireMode.syntheticEntry.value = makeDomainEntry({
+      seniority_number: 2,
+      employee_number: '_new_hire',
+      name: 'You (New Hire)',
+      base: 'JFK',
+      seat: 'FO',
+      fleet: '737',
+      retire_date: '2091-06-15',
+    })
+
+    const { snapshot, lens } = useEffectiveSeniorityEngine()
+    expect(snapshot.value).not.toBeNull()
+    expect(snapshot.value!.entries).toHaveLength(2)
+    expect(snapshot.value!.byEmployeeNumber.get('_new_hire')).toBeDefined()
+    expect(lens.value).not.toBeNull()
+    expect(lens.value!.anchor!.employeeNumber).toBe('_new_hire')
+  })
+
+  it('falls back to base lens when synthetic entry not configured', () => {
+    mockStore.entries = [makeEntry({ seniority_number: 1, employee_number: 'E1' })]
+    mockUserStore.profile = { employee_number: 'E1' }
+    mockNewHireMode.syntheticEntry.value = null // not configured yet
+
+    const { snapshot, lens } = useEffectiveSeniorityEngine()
+    expect(snapshot.value!.entries).toHaveLength(1)
+    expect(lens.value).not.toBeNull()
+    expect(lens.value!.anchor!.employeeNumber).toBe('E1')
+  })
+
+  it('returns null snapshot when no entries exist even in new hire mode', () => {
+    mockStore.entries = []
+    mockNewHireMode.syntheticEntry.value = makeDomainEntry({ employee_number: '_new_hire' })
+
+    const { snapshot } = useEffectiveSeniorityEngine()
+    expect(snapshot.value).toBeNull()
+  })
+})

--- a/app/composables/useEffectiveSeniorityEngine.ts
+++ b/app/composables/useEffectiveSeniorityEngine.ts
@@ -1,0 +1,38 @@
+import type { SenioritySnapshot, SeniorityLens, PilotAnchor } from '#shared/utils/seniority-engine'
+import { createSnapshot, createLens } from '#shared/utils/seniority-engine'
+import { useSeniorityStore } from '~/stores/seniority'
+import { useSeniorityEngine } from './useSeniorityEngine'
+import { useNewHireMode } from './useNewHireMode'
+
+/**
+ * Sits above useSeniorityEngine and handles the mode switch:
+ *   - Employee ID mode → delegates to the pure engine
+ *   - New Hire mode → builds an augmented snapshot with the synthetic entry
+ *
+ * useSeniorityEngine stays pure; new-hire logic never crosses into the engine.
+ */
+export function useEffectiveSeniorityEngine() {
+  const seniorityStore = useSeniorityStore()
+  const { snapshot: baseSnapshot, lens: baseLens } = useSeniorityEngine()
+  const newHireMode = useNewHireMode()
+
+  const snapshot = computed<SenioritySnapshot | null>(() => {
+    const synthetic = newHireMode.syntheticEntry.value
+    if (!synthetic) return baseSnapshot.value
+    if (seniorityStore.entries.length === 0) return null
+    return createSnapshot([...seniorityStore.entries, synthetic])
+  })
+
+  const lens = computed<SeniorityLens | null>(() => {
+    const synthetic = newHireMode.syntheticEntry.value
+    if (!snapshot.value || !synthetic) return baseLens.value
+    const anchor: PilotAnchor = {
+      seniorityNumber: synthetic.seniority_number,
+      retireDate: synthetic.retire_date,
+      employeeNumber: synthetic.employee_number,
+    }
+    return createLens(snapshot.value, anchor)
+  })
+
+  return { snapshot, lens }
+}

--- a/app/composables/useNewHireMode.test.ts
+++ b/app/composables/useNewHireMode.test.ts
@@ -55,41 +55,17 @@ describe('useNewHireMode', () => {
     })
   })
 
-  describe('isActive', () => {
-    it('is false when not enabled', () => {
-      mockUserStore.profile = makeProfile({ employee_number: '999' })
-      mockSeniorityStore.entries = [makeEntry({ employee_number: '100' })]
-      const { isActive } = useNewHireMode()
-      expect(isActive.value).toBe(false)
-    })
-
-    it('is false when enabled but user is found in list', () => {
-      mockUserStore.profile = makeProfile({ employee_number: '100' })
-      mockSeniorityStore.entries = [makeEntry({ employee_number: '100' })]
-      const { enabled, isActive } = useNewHireMode()
-      enabled.value = true
-      expect(isActive.value).toBe(false)
-    })
-
-    it('is true when enabled and user not found in list', () => {
-      mockUserStore.profile = makeProfile({ employee_number: '999' })
-      mockSeniorityStore.entries = [makeEntry({ employee_number: '100' })]
-      const { enabled, isActive } = useNewHireMode()
-      enabled.value = true
-      expect(isActive.value).toBe(true)
-    })
-  })
-
   describe('syntheticEntry', () => {
     it('is null when not active', () => {
       const { syntheticEntry } = useNewHireMode()
       expect(syntheticEntry.value).toBeNull()
     })
 
-    it('is null when active but no employee number', () => {
+    it('is null when enabled but not configured', () => {
       mockUserStore.profile = makeProfile({ employee_number: null })
       const { enabled, syntheticEntry } = useNewHireMode()
       enabled.value = true
+      // syntheticEntry is null because isConfigured is false (no base/seat/fleet/birthDate)
       expect(syntheticEntry.value).toBeNull()
     })
 
@@ -109,7 +85,7 @@ describe('useNewHireMode', () => {
 
       expect(mode.syntheticEntry.value).not.toBeNull()
       expect(mode.syntheticEntry.value!.seniority_number).toBe(51)
-      expect(mode.syntheticEntry.value!.employee_number).toBe('999')
+      expect(mode.syntheticEntry.value!.employee_number).toBe('_new_hire')
       expect(mode.syntheticEntry.value!.name).toBe('You (New Hire)')
     })
 
@@ -184,10 +160,17 @@ describe('useNewHireMode', () => {
   })
 
   describe('retireDate', () => {
-    it('computes retireDate from birthDate + 65 years', () => {
+    it('defaults to birthDate + 65 years when profile has no retirement age', () => {
       const { birthDate, retireDate } = useNewHireMode()
       birthDate.value = '1990-06-15'
       expect(retireDate.value).toBe('2055-06-15')
+    })
+
+    it('uses profile mandatory_retirement_age when set', () => {
+      mockUserStore.profile = makeProfile({ mandatory_retirement_age: 60 })
+      const { birthDate, retireDate } = useNewHireMode()
+      birthDate.value = '1990-06-15'
+      expect(retireDate.value).toBe('2050-06-15')
     })
 
     it('includes computed retireDate in synthetic entry', () => {

--- a/app/composables/useNewHireMode.ts
+++ b/app/composables/useNewHireMode.ts
@@ -20,6 +20,16 @@ export function useNewHireMode() {
 
   if (!_localStorageInitialized && import.meta.client && typeof localStorage !== 'undefined') {
     _localStorageInitialized = true
+
+    // Reset new-hire config when the user actively changes their employee number.
+    // Skip the initial profile hydration (undefined → value) to avoid wiping
+    // localStorage-restored state on page load.
+    watch(
+      () => userStore.profile?.employee_number,
+      (newVal, oldVal) => {
+        if (oldVal != null && newVal !== oldVal) reset()
+      },
+    )
     if (localStorage.getItem(STORAGE_KEY) === 'true') {
       enabled.value = true
     }
@@ -59,13 +69,12 @@ export function useNewHireMode() {
     return seniorityStore.entries.some((e) => e.employee_number === empNum)
   })
 
-  const isActive = computed(() => enabled.value && !realUserFound.value)
-
   const retireDate = computed(() => {
     if (!birthDate.value) return null
     const bd = new Date(birthDate.value)
     const retire = new Date(bd)
-    retire.setFullYear(retire.getFullYear() + 65)
+    const retirementAge = userStore.profile?.mandatory_retirement_age ?? 65
+    retire.setFullYear(retire.getFullYear() + retirementAge)
     return retire.toISOString().split('T')[0]!
   })
 
@@ -77,10 +86,9 @@ export function useNewHireMode() {
   )
 
   const syntheticEntry = computed<SeniorityEntry | null>(() => {
-    if (!isActive.value) return null
+    if (!enabled.value) return null
     if (!isConfigured.value) return null
-    const empNum = userStore.profile?.employee_number
-    if (!empNum) return null
+    const empNum = '_new_hire'
     const maxSenNum = seniorityStore.entries.reduce(
       (max, e) => Math.max(max, e.seniority_number),
       0,
@@ -97,6 +105,14 @@ export function useNewHireMode() {
     }
   })
 
+  function reset() {
+    enabled.value = false
+    selectedBase.value = null
+    selectedSeat.value = null
+    selectedFleet.value = null
+    birthDate.value = null
+  }
+
   return {
     enabled,
     selectedBase,
@@ -107,9 +123,9 @@ export function useNewHireMode() {
     availableSeats,
     availableFleets,
     realUserFound,
-    isActive,
     isConfigured,
     retireDate,
     syntheticEntry,
+    reset,
   }
 }

--- a/app/composables/useQualDemographics.ts
+++ b/app/composables/useQualDemographics.ts
@@ -4,6 +4,9 @@ import { uniqueEntryValues } from '#shared/utils/entry-filters'
 import { useSeniorityStore } from '~/stores/seniority'
 import { useUserStore } from '~/stores/user'
 import { useUserEntry } from './useUserEntry'
+// Intentionally uses the base engine — demographics reflect the real pilot population,
+// not the synthetic new-hire entry. Callers needing user-specific markers (YOS, holdable)
+// must fall back to newHireMode.syntheticEntry at the call site.
 import { useSeniorityEngine } from './useSeniorityEngine'
 
 export function useQualDemographics() {

--- a/app/composables/useQualProjections.ts
+++ b/app/composables/useQualProjections.ts
@@ -2,7 +2,7 @@ import { createScenario } from '#shared/utils/seniority-engine'
 import type { QualSpec } from '#shared/utils/seniority-engine'
 import { DEFAULT_GROWTH_CONFIG, type GrowthConfig } from '#shared/types/growth-config'
 import type { ComputedRef, Ref } from 'vue'
-import { useSeniorityEngine } from './useSeniorityEngine'
+import { useEffectiveSeniorityEngine } from './useEffectiveSeniorityEngine'
 
 const BANNER_KEY = 'qual-projections-banner-dismissed'
 
@@ -10,7 +10,7 @@ export function useQualProjections(
   qualSpec: ComputedRef<QualSpec> = computed(() => ({})),
   growthConfig: Ref<GrowthConfig> = ref({ ...DEFAULT_GROWTH_CONFIG }),
 ) {
-  const { lens } = useSeniorityEngine()
+  const { lens } = useEffectiveSeniorityEngine()
 
   const isBannerDismissed = ref(
     typeof localStorage !== 'undefined' ? localStorage.getItem(BANNER_KEY) === 'true' : false,

--- a/app/composables/useSeniorityEngine.test.ts
+++ b/app/composables/useSeniorityEngine.test.ts
@@ -1,22 +1,14 @@
 import { describe, it, expect, vi } from 'vitest'
 import { useSeniorityEngine } from './useSeniorityEngine'
 
-// Mock stores and composables
 const mockStore = vi.hoisted(() => ({ entries: [] as any[] }))
 const mockUserStore = vi.hoisted(() => ({ profile: null as any }))
-const mockNewHireMode = vi.hoisted(() => ({
-  isActive: { value: false },
-  syntheticEntry: { value: null as any },
-}))
 
 vi.mock('~/stores/seniority', () => ({
   useSeniorityStore: () => mockStore,
 }))
 vi.mock('~/stores/user', () => ({
   useUserStore: () => mockUserStore,
-}))
-vi.mock('./useNewHireMode', () => ({
-  useNewHireMode: () => mockNewHireMode,
 }))
 
 const { makeEntry } = await import('#shared/test-utils/factories')
@@ -56,26 +48,10 @@ describe('useSeniorityEngine', () => {
     expect(lens.value).toBeNull()
   })
 
-  it('injects synthetic entry into snapshot when new-hire mode is active', () => {
-    mockStore.entries = [makeEntry({ seniority_number: 1, employee_number: 'E1' })]
-    mockUserStore.profile = { employee_number: 'NEW' }
-    mockNewHireMode.isActive.value = true
-    mockNewHireMode.syntheticEntry.value = {
-      seniority_number: 2,
-      employee_number: 'NEW',
-      name: 'You (New Hire)',
-      seat: 'FO',
-      base: 'JFK',
-      fleet: '737',
-      hire_date: '2026-03-19',
-      retire_date: '2055-06-15',
-    }
-
-    const { snapshot, lens } = useSeniorityEngine()
-    expect(snapshot.value).not.toBeNull()
-    expect(snapshot.value!.entries).toHaveLength(2)
-    expect(snapshot.value!.byEmployeeNumber.get('NEW')).toBeDefined()
-    expect(lens.value).not.toBeNull()
-    expect(lens.value!.anchor!.employeeNumber).toBe('NEW')
+  it('returns null lens when user has no employee number', () => {
+    mockStore.entries = [makeEntry()]
+    mockUserStore.profile = { employee_number: null }
+    const { lens } = useSeniorityEngine()
+    expect(lens.value).toBeNull()
   })
 })

--- a/app/composables/useSeniorityEngine.ts
+++ b/app/composables/useSeniorityEngine.ts
@@ -1,36 +1,26 @@
-import type { SeniorityEntry } from '#shared/schemas/seniority-list'
 import type { SenioritySnapshot, SeniorityLens, PilotAnchor } from '#shared/utils/seniority-engine'
 import { createSnapshot, createLens } from '#shared/utils/seniority-engine'
 import { useSeniorityStore } from '~/stores/seniority'
 import { useUserStore } from '~/stores/user'
-import { useNewHireMode } from './useNewHireMode'
 
 export function useSeniorityEngine() {
   const seniorityStore = useSeniorityStore()
   const userStore = useUserStore()
-  const newHireMode = useNewHireMode()
 
   const snapshot = computed<SenioritySnapshot | null>(() => {
     if (seniorityStore.entries.length === 0) return null
-    const baseEntries: SeniorityEntry[] = [...seniorityStore.entries]
-    const synthetic = newHireMode.syntheticEntry.value
-    if (newHireMode.isActive.value && synthetic) {
-      baseEntries.push(synthetic)
-    }
-    return createSnapshot(baseEntries)
+    return createSnapshot([...seniorityStore.entries])
   })
 
   const lens = computed<SeniorityLens | null>(() => {
     if (!snapshot.value) return null
-    // Try real entry first, fall back to synthetic entry for new-hire mode
     const empNum = userStore.profile?.employee_number
     if (!empNum) return null
     const entry = seniorityStore.entries.find(e => e.employee_number === empNum)
-      ?? (newHireMode.isActive.value ? newHireMode.syntheticEntry.value : null)
     if (!entry) return null
     const anchor: PilotAnchor = {
       seniorityNumber: entry.seniority_number,
-      retireDate: entry.retire_date ?? null,
+      retireDate: entry.retire_date,
       employeeNumber: entry.employee_number,
     }
     return createLens(snapshot.value, anchor)

--- a/app/composables/useUserTrajectory.test.ts
+++ b/app/composables/useUserTrajectory.test.ts
@@ -24,7 +24,6 @@ vi.mock('~/stores/user', () => ({
 vi.mock('./useNewHireMode', () => ({
   useNewHireMode: () => ({
     enabled: { value: false },
-    isActive: { value: false },
     syntheticEntry: { value: null },
     realUserFound: { value: false },
     selectedBase: { value: null },

--- a/app/composables/useUserTrajectory.ts
+++ b/app/composables/useUserTrajectory.ts
@@ -2,10 +2,10 @@ import { createScenario } from '#shared/utils/seniority-engine'
 import type { QualSpec } from '#shared/utils/seniority-engine'
 import { DEFAULT_GROWTH_CONFIG, type GrowthConfig } from '#shared/types/growth-config'
 import type { Ref } from 'vue'
-import { useSeniorityEngine } from './useSeniorityEngine'
+import { useEffectiveSeniorityEngine } from './useEffectiveSeniorityEngine'
 
 export function useUserTrajectory(growthConfig: Ref<GrowthConfig> = ref({ ...DEFAULT_GROWTH_CONFIG })) {
-  const { lens } = useSeniorityEngine()
+  const { lens } = useEffectiveSeniorityEngine()
 
   const scenario = computed(() => createScenario({ growthConfig: growthConfig.value }))
 

--- a/app/pages/settings.vue
+++ b/app/pages/settings.vue
@@ -12,6 +12,7 @@ definePageMeta({ layout: 'dashboard', middleware: 'auth' })
       <div class="max-w-2xl mx-auto space-y-6 p-4 sm:p-6">
         <SettingsProfileCard />
         <SettingsPreferencesCard />
+        <SettingsNewHireModeCard />
         <SettingsEmailCard />
         <SettingsPasswordCard />
       </div>

--- a/shared/schemas/seniority-list.ts
+++ b/shared/schemas/seniority-list.ts
@@ -25,6 +25,7 @@ export type SeniorityEntry = z.infer<typeof SeniorityEntrySchema>
 export const SeniorityListIdSchema = z.object({
   id: z.string().uuid('Invalid list ID'),
 })
+export type SeniorityListId = z.infer<typeof SeniorityListIdSchema>
 
 export const CreateSeniorityListSchema = z.object({
   effective_date: z.string().regex(ISO_DATE_REGEX, 'Invalid date format'),
@@ -58,7 +59,6 @@ export const SeniorityEntryResponseSchema = z.object({
   id: z.string().uuid(),
   list_id: z.string().uuid(),
 })
-
 export type SeniorityEntryResponse = z.infer<typeof SeniorityEntryResponseSchema>
 
 export const CreateSeniorityListResponseSchema = z.object({

--- a/shared/utils/qual-analytics.ts
+++ b/shared/utils/qual-analytics.ts
@@ -471,21 +471,29 @@ export function applyProjectionToSnapshots(
   projectionDate: Date,
   growthConfig?: GrowthConfig,
 ): QualDemographicScale[] {
+  // Use the same rank-based projection as buildTrajectory: fix total at original
+  // list size and subtract retirements from rank. The previous approach (re-filter
+  // to active entries, re-sort, lowerBound) kept the most junior pilot pinned at
+  // the bottom regardless of retirements above them.
   const today = new Date()
-  const todayActive = entries.filter((e) => isActiveAt(e, today))
-  const todaySorted = sortedSenNums(todayActive)
-  const currentPctl = todayActive.length > 0
-    ? companyPercentile(userSenNum, todaySorted, todayActive.length)
+  const totalPilots = entries.length
+  const aheadOfUser = entries.filter(e => e.seniority_number < userSenNum)
+  const initialRank = aheadOfUser.length + 1
+
+  const retiredAheadToday = aheadOfUser.filter(e => e.retire_date && new Date(e.retire_date) <= today).length
+  const currentRank = initialRank - retiredAheadToday
+  const currentPctl = totalPilots > 0
+    ? Math.round(((totalPilots - currentRank + 1) / totalPilots) * 100 * 10) / 10
     : 0
 
-  const projectedActive = entries.filter((e) => isActiveAt(e, projectionDate))
-  const projectedSorted = sortedSenNums(projectedActive)
+  const retiredAheadProjected = aheadOfUser.filter(e => e.retire_date && new Date(e.retire_date) <= projectionDate).length
+  const projectedRank = initialRank - retiredAheadProjected
   const additional = growthConfig?.enabled
-    ? computeAdditionalPilots(entries.length, growthConfig.annualRate, today, projectionDate)
+    ? computeAdditionalPilots(totalPilots, growthConfig.annualRate, today, projectionDate)
     : 0
-  const projectedTotal = projectedActive.length + additional
+  const projectedTotal = totalPilots + additional
   const userPctl = projectedTotal > 0
-    ? companyPercentile(userSenNum, projectedSorted, projectedTotal)
+    ? Math.round(((projectedTotal - projectedRank + 1) / projectedTotal) * 100 * 10) / 10
     : 0
 
   return snapshots.map((snap) => ({


### PR DESCRIPTION
Adds an effective engine that integrates the new-hire domain idea without reaching down into the engine calculations itself.

fix(engine): guard already-retired entries in percentileCrossing, fix demographics filter, add compareTrajectories scope note, handle new-hire cell detection fallback

refactor(new-hire-mode): consolidate boundary between composable layer and engine

- Make retire_date optional in SeniorityEntry schema (synthetic new-hire entries have no retire date until birthDate is set)
- Fix null safety in useNewHireMode syntheticEntry (retire_date ?? undefined, not !)
- Add SeniorityListId type export to seniority-list schema

refactor(new-hire-mode): remove isActive alias, fix UI guards, and harden composable

- Remove `isActive` computed from useNewHireMode; consumers use `enabled` (UI toggle) or `syntheticEntry` nullability (engine signal)
- Simplify useEffectiveSeniorityEngine to key off syntheticEntry directly
- Remove dead isAnchorCurrent fallback in useDashboardStats
- Use profile mandatory_retirement_age instead of hardcoded 65
- Fix localStorage persistence race: employee_number watcher fired on initial hydration, wiping restored state
- Register all watchers once inside _localStorageInitialized guard
- Fix hasEmployeeNumber gates in PositionTab, RetirementsTab, TrajectoryTab, and useDashboardStats to include syntheticEntry
- Fix DemographicsTab: synthetic-first fallback for userYos and userSeniorityNumber (JuniorCaptainTable holdable dots)
- Disable new-hire mode toggle in Settings when realUserFound is true
- Document intentional base-engine usage in useQualDemographics and useCompanyStats