### PR TITLE
feat(auth): open public registration and add legal pages

### DIFF
--- a/app/components/AppFooter.vue
+++ b/app/components/AppFooter.vue
@@ -1,0 +1,15 @@
+<template>
+  <footer class="border-t border-(--ui-border) bg-(--ui-bg)">
+    <UContainer class="py-6">
+      <div class="flex flex-col sm:flex-row items-center justify-between gap-4 text-sm text-muted">
+        <span>© {{ new Date().getFullYear() }} SeniorityGuru</span>
+        <nav class="flex flex-wrap justify-center gap-x-5 gap-y-1">
+          <ULink to="/how-it-works" class="hover:text-default transition-colors">How It Works</ULink>
+          <ULink to="/privacy" class="hover:text-default transition-colors">Privacy</ULink>
+          <ULink to="/terms" class="hover:text-default transition-colors">Terms</ULink>
+          <ULink to="mailto:support@seniorityguru.com" class="hover:text-default transition-colors">Contact</ULink>
+        </nav>
+      </div>
+    </UContainer>
+  </footer>
+</template>

--- a/app/components/AppHeader.vue
+++ b/app/components/AppHeader.vue
@@ -20,7 +20,10 @@ const { signOut } = useSignOut()
           <UButton to="/dashboard" variant="ghost" size="sm">Go to Dashboard</UButton>
           <UButton variant="ghost" size="sm" @click="signOut">Sign out</UButton>
         </template>
-        <UButton v-else to="/auth/login" size="sm">Sign in</UButton>
+        <template v-else>
+          <UButton to="/auth/login" variant="ghost" size="sm">Sign in</UButton>
+          <UButton to="/auth/signup" size="sm">Sign up</UButton>
+        </template>
       </ClientOnly>
     </template>
   </UHeader>

--- a/app/layouts/default.vue
+++ b/app/layouts/default.vue
@@ -6,5 +6,6 @@
         <slot />
       </UContainer>
     </UMain>
+    <AppFooter />
   </div>
 </template>

--- a/app/pages/auth/login.vue
+++ b/app/pages/auth/login.vue
@@ -10,7 +10,7 @@ const loading = ref(false)
 
 const state = reactive<LoginState>({
   email: '',
-  password: ''
+  password: '',
 })
 
 async function onSubmit() {
@@ -23,26 +23,29 @@ async function onSubmit() {
     return
   }
 
-  navigateTo('/dashboard')
+  await navigateTo('/dashboard')
 }
 </script>
 
 <template>
   <div>
     <h1 class="text-2xl font-bold mb-6 text-center">Sign in</h1>
+
     <UForm :schema="LoginSchema" :state="state" class="space-y-4" @submit="onSubmit">
       <UFormField label="Email" name="email">
-        <UInput v-model="state.email" type="email" placeholder="you@example.com" class="w-full" />
+        <UInput v-model="state.email" type="email" placeholder="you@example.com" class="w-full" autocomplete="email" />
       </UFormField>
       <UFormField label="Password" name="password">
-        <UInput v-model="state.password" type="password" class="w-full" />
+        <UInput v-model="state.password" type="password" class="w-full" autocomplete="current-password" />
       </UFormField>
       <UButton type="submit" class="w-full" :loading="loading">Sign in</UButton>
     </UForm>
+
     <div class="mt-4 text-center text-sm space-y-2">
       <div>
         <ULink to="/auth/reset-password" class="text-primary hover:underline">Forgot your password?</ULink>
       </div>
+
       <div class="text-muted">
         Don't have an account?
         <ULink to="/auth/signup" class="text-primary hover:underline">Sign up</ULink>

--- a/app/pages/auth/signup.test.ts
+++ b/app/pages/auth/signup.test.ts
@@ -2,23 +2,22 @@ import { describe, it, expect } from 'vitest'
 import { mountSuspended } from '@nuxt/test-utils/runtime'
 import SignupPage from './signup.vue'
 
-describe('signup page (invite-only)', () => {
-  it('renders the invite-only message', async () => {
+describe('signup page', () => {
+  it('renders the create account heading', async () => {
     const wrapper = await mountSuspended(SignupPage)
-    expect(wrapper.text()).toContain('Invite Only')
-    expect(wrapper.text()).toContain('invite-only')
+    expect(wrapper.text()).toContain('Create your account')
   })
 
-  it('mentions checking junk or spam folder', async () => {
+  it('renders a signup form with email and password fields', async () => {
     const wrapper = await mountSuspended(SignupPage)
-    expect(wrapper.text()).toContain('junk or spam folder')
+    expect(wrapper.find('input[type="email"]').exists()).toBe(true)
+    expect(wrapper.findAll('input[type="password"]').length).toBe(2)
   })
 
-  it('does not render a signup form', async () => {
+  it('does not render OAuth buttons', async () => {
     const wrapper = await mountSuspended(SignupPage)
-    expect(wrapper.find('form').exists()).toBe(false)
-    expect(wrapper.find('input[type="email"]').exists()).toBe(false)
-    expect(wrapper.find('input[type="password"]').exists()).toBe(false)
+    expect(wrapper.text()).not.toContain('Continue with Google')
+    expect(wrapper.text()).not.toContain('Continue with Apple')
   })
 
   it('shows a link to the login page', async () => {

--- a/app/pages/auth/signup.vue
+++ b/app/pages/auth/signup.vue
@@ -1,22 +1,75 @@
 <script setup lang="ts">
+import { SignUpSchema } from '#shared/schemas/auth'
+import type { SignUpState } from '#shared/schemas/auth'
+
 definePageMeta({ layout: 'auth' })
+
+const supabase = useSupabaseClient()
+const toast = useToast()
+const loading = ref(false)
+const successEmail = ref<string | null>(null)
+
+const state = reactive<Omit<SignUpState, 'icaoCode'>>({
+  email: '',
+  password: '',
+  confirmPassword: '',
+})
+
+async function onSubmit() {
+  loading.value = true
+  const { error } = await supabase.auth.signUp({
+    email: state.email,
+    password: state.password,
+    options: { emailRedirectTo: `${window.location.origin}/auth/confirm` },
+  })
+  loading.value = false
+
+  if (error) {
+    toast.add({ title: error.message, color: 'error' })
+    return
+  }
+
+  successEmail.value = state.email
+}
+
 </script>
 
 <template>
   <div>
-    <h1 class="text-2xl font-bold mb-6 text-center">Invite Only</h1>
+    <template v-if="successEmail">
+      <div class="text-center space-y-3">
+        <UIcon name="i-lucide-mail-check" class="size-12 text-primary mx-auto" />
+        <h1 class="text-2xl font-bold">Check your email</h1>
+        <p class="text-muted text-sm">
+          We sent a confirmation link to <span class="font-medium text-default">{{ successEmail }}</span>.
+          Click it to activate your account.
+        </p>
+        <p class="text-xs text-muted">
+          Can't find it? Check your spam folder.
+        </p>
+      </div>
+    </template>
 
-    <UAlert
-      icon="i-lucide-lock"
-      color="info"
-      variant="soft"
-      title="This service is currently invite-only"
-      description="If you've received an invite, check your email for the access link (check your junk or spam folder too). Contact your administrator to request access."
-    />
+    <template v-else>
+      <h1 class="text-2xl font-bold mb-6 text-center">Create your account</h1>
 
-    <p class="mt-4 text-center text-sm text-muted">
-      Already have an account?
-      <ULink to="/auth/login" class="text-primary hover:underline">Sign in</ULink>
-    </p>
+      <UForm :schema="SignUpSchema" :state="state" class="space-y-4" @submit="onSubmit">
+        <UFormField label="Email" name="email">
+          <UInput v-model="state.email" type="email" placeholder="you@example.com" class="w-full" autocomplete="email" />
+        </UFormField>
+        <UFormField label="Password" name="password">
+          <UInput v-model="state.password" type="password" class="w-full" autocomplete="new-password" />
+        </UFormField>
+        <UFormField label="Confirm password" name="confirmPassword">
+          <UInput v-model="state.confirmPassword" type="password" class="w-full" autocomplete="new-password" />
+        </UFormField>
+        <UButton type="submit" class="w-full" :loading="loading">Create account</UButton>
+      </UForm>
+
+      <p class="mt-4 text-center text-sm text-muted">
+        Already have an account?
+        <ULink to="/auth/login" class="text-primary hover:underline">Sign in</ULink>
+      </p>
+    </template>
   </div>
 </template>

--- a/app/pages/index.test.ts
+++ b/app/pages/index.test.ts
@@ -39,10 +39,10 @@ describe('index.vue — CTA conditional rendering', () => {
     mockUser.value = null
   })
 
-  it('shows "Request Access" hero CTA when user is not signed in', async () => {
+  it('shows "Get Started" hero CTA when user is not signed in', async () => {
     const IndexPage = await import('./index.vue')
     const wrapper = await mountSuspended(IndexPage.default)
-    expect(wrapper.text()).toContain('Request Access')
+    expect(wrapper.text()).toContain('Get Started')
   })
 
   it('shows "Go to Dashboard" hero CTA when user is signed in', async () => {
@@ -59,9 +59,9 @@ describe('index.vue — CTA conditional rendering', () => {
     expect(wrapper.html()).toContain('href="/dashboard"')
   })
 
-  it('hero CTA links to /auth/login when user is not signed in', async () => {
+  it('hero CTA links to /auth/signup when user is not signed in', async () => {
     const IndexPage = await import('./index.vue')
     const wrapper = await mountSuspended(IndexPage.default)
-    expect(wrapper.html()).toContain('href="/auth/login"')
+    expect(wrapper.html()).toContain('href="/auth/signup"')
   })
 })

--- a/app/pages/index.vue
+++ b/app/pages/index.vue
@@ -3,6 +3,14 @@ import type { QualDemographicScale } from '#shared/utils/qual-analytics'
 
 definePageMeta({ layout: 'default' })
 
+useSeoMeta({
+  title: 'SeniorityGuru — Pilot Seniority Tracker',
+  description: 'Track your seniority rank, percentile, and career trajectory. Upload your airline\'s seniority list and see exactly where you stand.',
+  ogTitle: 'SeniorityGuru — Pilot Seniority Tracker',
+  ogDescription: 'Upload your airline\'s seniority list and instantly see your rank, percentile, and career projections.',
+  twitterCard: 'summary',
+})
+
 const user = useSupabaseUser()
 
 const howItWorksSteps = [
@@ -294,8 +302,8 @@ const demoWaveBuckets = computed(() => demoWaveData[demoQual.value])
               <UButton v-if="user" to="/dashboard" size="xl" icon="i-lucide-arrow-right" trailing>
                 Go to Dashboard
               </UButton>
-              <UButton v-else to="/auth/login" size="xl" icon="i-lucide-arrow-right" trailing>
-                Request Access
+              <UButton v-else to="/auth/signup" size="xl" icon="i-lucide-arrow-right" trailing>
+                Get Started
               </UButton>
             </ClientOnly>
             <UButton to="#demo" size="xl" variant="ghost" icon="i-lucide-play-circle" trailing>
@@ -677,17 +685,17 @@ const demoWaveBuckets = computed(() => demoWaveData[demoQual.value])
       <UContainer>
         <div class="max-w-xl mx-auto space-y-6">
           <h2 class="text-2xl sm:text-3xl font-bold tracking-tight">
-            Currently in open beta
+            Know where you stand.
           </h2>
           <p class="text-muted">
-            Request access to start tracking your seniority today.
+            Free to use. Sign up and know where you stand.
           </p>
           <ClientOnly>
             <UButton v-if="user" to="/dashboard" size="xl" icon="i-lucide-arrow-right" trailing>
               Go to Dashboard
             </UButton>
-            <UButton v-else to="/auth/login" size="xl" icon="i-lucide-arrow-right" trailing>
-              Request Access
+            <UButton v-else to="/auth/signup" size="xl" icon="i-lucide-arrow-right" trailing>
+              Get Started
             </UButton>
           </ClientOnly>
 

--- a/app/pages/privacy.vue
+++ b/app/pages/privacy.vue
@@ -1,0 +1,118 @@
+<script setup lang="ts">
+definePageMeta({ layout: 'default' })
+
+useSeoMeta({
+  title: 'Privacy Policy — SeniorityGuru',
+  description: 'How SeniorityGuru collects, uses, and protects your data.',
+})
+</script>
+
+<template>
+  <div class="max-w-3xl mx-auto prose prose-sm dark:prose-invert">
+    <h1>Privacy Policy</h1>
+    <p class="text-muted text-sm">Last updated: March 2026</p>
+
+    <h2>1. Who we are</h2>
+    <p>
+      SeniorityGuru is operated by Michael Dempsey, 3 Jefts Ter, Stoneham MA 02180, USA
+      (<ULink to="mailto:support@seniorityguru.com" class="text-primary hover:underline">support@seniorityguru.com</ULink>).
+      For the purposes of the EU General Data Protection Regulation (GDPR) and UK GDPR, Michael Dempsey
+      is the data controller.
+    </p>
+
+    <h2>2. What we collect</h2>
+    <p>
+      When you create an account we collect your email address. When you upload a seniority list we store
+      the derived data (rank, hire dates, retire dates, base, seat, fleet assignments) to power your
+      dashboard. We do not store the source file or any metadata about where the list came from.
+      We also collect standard server logs (IP address, browser type, pages visited) via Vercel's
+      infrastructure.
+    </p>
+
+    <h2>3. Lawful basis for processing</h2>
+    <p>
+      We process your personal data on the basis of <strong>contract performance</strong> (Article 6(1)(b) GDPR)
+      — processing is necessary to provide the service you signed up for. We do not rely on consent as a
+      lawful basis for core service processing.
+    </p>
+
+    <h2>4. How we use it</h2>
+    <p>
+      Your data is used solely to operate the service — to display your seniority standing, run projections,
+      and show comparisons between uploads. We do not sell your data, share it with third parties for
+      marketing purposes, or use it to train AI or machine-learning models.
+    </p>
+
+    <h2>5. Third-party processors</h2>
+    <ul>
+      <li>
+        <strong>Supabase, Inc.</strong> — database and authentication. Your data is stored in
+        Supabase-managed Postgres. Supabase is SOC 2 Type II certified. Data processing is governed
+        by a Data Processing Agreement (DPA) incorporating EU Standard Contractual Clauses (Module Two),
+        a UK Addendum, and a Swiss Addendum.
+      </li>
+      <li>
+        <strong>Vercel, Inc.</strong> — hosting and edge delivery. Vercel handles request routing and
+        serves the application. Data processing is governed by a Data Processing Agreement with Vercel.
+      </li>
+    </ul>
+    <p>
+      We do not use third-party analytics that track individual behaviour across the web. Vercel Analytics
+      is cookieless and does not track individuals.
+    </p>
+
+    <h2>6. International data transfers</h2>
+    <p>
+      SeniorityGuru is operated from the United States. If you are located in the European Economic Area,
+      United Kingdom, or Switzerland, your personal data is transferred to the US under appropriate
+      safeguards: EU Standard Contractual Clauses (SCCs) with Supabase cover EEA transfers; a UK Addendum
+      covers UK transfers; and a Swiss Addendum covers Swiss transfers. Copies of the applicable SCCs
+      are available on request.
+    </p>
+
+    <h2>7. Data retention</h2>
+    <p>
+      Your account data and seniority list data are retained for as long as your account is active.
+      Deleting your account permanently removes all associated data, including uploaded lists and derived
+      analytics. There is no recovery after deletion.
+    </p>
+
+    <h2>8. Your rights</h2>
+    <p>
+      Depending on your location, you may have the following rights regarding your personal data:
+    </p>
+    <ul>
+      <li><strong>Access</strong> — request a copy of the data we hold about you</li>
+      <li><strong>Rectification</strong> — request correction of inaccurate data</li>
+      <li><strong>Erasure</strong> — request deletion of your data (you can also do this directly by deleting your account)</li>
+      <li><strong>Restriction</strong> — request that we limit how we process your data</li>
+      <li><strong>Portability</strong> — request your data in a structured, machine-readable format</li>
+      <li><strong>Objection</strong> — object to processing based on legitimate interests</li>
+      <li><strong>Withdraw consent</strong> — where processing is based on consent, withdraw it at any time</li>
+      <li><strong>Lodge a complaint</strong> — you have the right to lodge a complaint with your local supervisory authority</li>
+    </ul>
+    <p>
+      To exercise any of these rights, contact us at
+      <ULink to="mailto:support@seniorityguru.com" class="text-primary hover:underline">support@seniorityguru.com</ULink>.
+      We will respond within 30 days.
+    </p>
+
+    <h2>9. Cookies</h2>
+    <p>
+      We use a single session cookie set by Supabase to maintain your login state. This cookie is
+      strictly necessary for the service to function. No advertising or tracking cookies are set.
+    </p>
+
+    <h2>10. Changes to this policy</h2>
+    <p>
+      If we make material changes to this policy we will notify you by email or by posting a notice in the
+      application before the changes take effect.
+    </p>
+
+    <h2>11. Contact</h2>
+    <p>
+      Questions about this policy or requests to exercise your rights? Email us at
+      <ULink to="mailto:support@seniorityguru.com" class="text-primary hover:underline">support@seniorityguru.com</ULink>.
+    </p>
+  </div>
+</template>

--- a/app/pages/terms.vue
+++ b/app/pages/terms.vue
@@ -1,0 +1,83 @@
+<script setup lang="ts">
+definePageMeta({ layout: 'default' })
+
+useSeoMeta({
+  title: 'Terms of Service — SeniorityGuru',
+  description: 'Terms and conditions for using SeniorityGuru.',
+})
+</script>
+
+<template>
+  <div class="max-w-3xl mx-auto prose prose-sm dark:prose-invert">
+    <h1>Terms of Service</h1>
+    <p class="text-muted text-sm">Last updated: March 2025</p>
+
+    <h2>1. Acceptance</h2>
+    <p>
+      By creating an account or using SeniorityGuru you agree to these terms. If you do not agree,
+      do not use the service.
+    </p>
+
+    <h2>2. What the service does</h2>
+    <p>
+      SeniorityGuru processes airline seniority spreadsheets you upload and presents derived analytics:
+      rank, percentile, position by base and seat, career trajectory projections, and list comparisons.
+      All projections are mathematical estimates — they are not career advice and are not guaranteed.
+    </p>
+
+    <h2>3. Acceptable use</h2>
+    <p>You agree not to:</p>
+    <ul>
+      <li>Upload data you do not have the right to use.</li>
+      <li>Attempt to scrape, reverse-engineer, or automate access to the service.</li>
+      <li>Use the service for any unlawful purpose.</li>
+      <li>Attempt to access other users' data.</li>
+    </ul>
+
+    <h2>4. Your data</h2>
+    <p>
+      You retain ownership of any data you upload. By uploading you grant SeniorityGuru a limited licence
+      to store and process that data for the sole purpose of providing the service to you. We do not claim
+      any ownership of your data and will not share it with third parties (see our
+      <ULink to="/privacy" class="text-primary hover:underline">Privacy Policy</ULink>).
+    </p>
+
+    <h2>5. Pricing</h2>
+    <p>
+      SeniorityGuru is currently free to use. We reserve the right to introduce pricing or impose
+      upload-size limits in the future. If we do, we will give you reasonable advance notice before
+      any changes take effect.
+    </p>
+
+    <h2>6. Disclaimers</h2>
+    <p>
+      The service is provided "as is" without warranties of any kind. Seniority projections are based on
+      publicly available modelling assumptions and historical data — actual outcomes will differ. Do not
+      make career decisions based solely on SeniorityGuru projections.
+    </p>
+
+    <h2>7. Limitation of liability</h2>
+    <p>
+      To the maximum extent permitted by law, SeniorityGuru is not liable for any indirect, incidental,
+      or consequential damages arising from your use of the service.
+    </p>
+
+    <h2>8. Termination</h2>
+    <p>
+      You may delete your account at any time. We may suspend or terminate accounts that violate these
+      terms. On termination, all your data is permanently deleted.
+    </p>
+
+    <h2>9. Changes to these terms</h2>
+    <p>
+      We may update these terms from time to time. Continued use of the service after changes are posted
+      constitutes acceptance of the revised terms.
+    </p>
+
+    <h2>10. Contact</h2>
+    <p>
+      Questions? Email us at
+      <ULink to="mailto:support@seniorityguru.com" class="text-primary hover:underline">support@seniorityguru.com</ULink>.
+    </p>
+  </div>
+</template>

--- a/e2e/auth.spec.ts
+++ b/e2e/auth.spec.ts
@@ -55,13 +55,15 @@ test.describe('Auth gates', () => {
 })
 
 // ---------------------------------------------------------------------------
-// Signup page (invite-only)
+// Signup page
 // ---------------------------------------------------------------------------
 
 test.describe('Signup', () => {
-  test('shows invite-only message', async ({ page, goto }) => {
+  test('shows the create account form', async ({ page, goto }) => {
     await goto('/auth/signup', { waitUntil: 'hydration' })
-    await expect(page.getByRole('heading', { name: 'Invite Only' })).toBeVisible()
+    await expect(page.getByRole('heading', { name: 'Create your account' })).toBeVisible()
+    await expect(page.locator('input[type="email"]')).toBeVisible()
+    await expect(page.locator('input[type="password"]').first()).toBeVisible()
   })
 })
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -2151,23 +2151,6 @@
         "node": ">=18.12.0"
       }
     },
-    "node_modules/@nuxt/test-utils/node_modules/crossws": {
-      "version": "0.4.4",
-      "resolved": "https://registry.npmjs.org/crossws/-/crossws-0.4.4.tgz",
-      "integrity": "sha512-w6c4OdpRNnudVmcgr7brb/+/HmYjMQvYToO/oTrprTwxRUiom3LYWU1PMWuD006okbUWpII1Ea9/+kwpUfmyRg==",
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "peer": true,
-      "peerDependencies": {
-        "srvx": ">=0.7.1"
-      },
-      "peerDependenciesMeta": {
-        "srvx": {
-          "optional": true
-        }
-      }
-    },
     "node_modules/@nuxt/test-utils/node_modules/h3-next": {
       "name": "h3",
       "version": "2.0.1-rc.11",

--- a/public/robots.txt
+++ b/public/robots.txt
@@ -1,0 +1,2 @@
+User-agent: *
+Allow: /


### PR DESCRIPTION
## Summary
- Replace invite-only gate with public email/password signup
- Add Privacy Policy (GDPR-compliant) and Terms of Service pages
- Add footer with legal links and `support@seniorityguru.com` contact
- Update landing page CTAs from "Request Access" to "Get Started"
- Add Sign up button to header for unauthenticated users

## Commits
- `b9be4df` feat(auth): open public registration and add legal pages