### PR TITLE
fix(auth): switch password recovery to OTP

### DIFF
--- a/app/pages/auth/confirm.test.ts
+++ b/app/pages/auth/confirm.test.ts
@@ -2,19 +2,14 @@ import { describe, it, expect, vi, beforeEach } from 'vitest'
 import { mountSuspended, mockNuxtImport } from '@nuxt/test-utils/runtime'
 import ConfirmPage from './confirm.vue'
 
-const { mockRoute, mockNavigateTo, mockOnAuthStateChange, mockUnsubscribe, mockSetSession, mockVerifyOtp } = vi.hoisted(() => ({
+const { mockRoute, mockNavigateTo, mockVerifyOtp } = vi.hoisted(() => ({
   mockRoute: { value: { query: {} as Record<string, string>, hash: '' } },
   mockNavigateTo: vi.fn().mockResolvedValue(undefined),
-  mockOnAuthStateChange: vi.fn(),
-  mockUnsubscribe: vi.fn(),
-  mockSetSession: vi.fn().mockResolvedValue({ data: {}, error: null }),
   mockVerifyOtp: vi.fn().mockResolvedValue({ error: null }),
 }))
 
 mockNuxtImport('useSupabaseClient', () => () => ({
   auth: {
-    onAuthStateChange: mockOnAuthStateChange,
-    setSession: mockSetSession,
     verifyOtp: mockVerifyOtp,
   },
 }))
@@ -26,26 +21,17 @@ describe('confirm page', () => {
     mockRoute.value = { query: {}, hash: '' }
     mockNavigateTo.mockReset()
     mockNavigateTo.mockResolvedValue(undefined)
-    mockOnAuthStateChange.mockReset()
-    mockOnAuthStateChange.mockReturnValue({ data: { subscription: { unsubscribe: mockUnsubscribe } } })
-    mockSetSession.mockReset()
-    mockSetSession.mockResolvedValue({ data: {}, error: null })
     mockVerifyOtp.mockReset()
     mockVerifyOtp.mockResolvedValue({ error: null })
   })
 
-  // --- Default OTP form ---
+  // --- Default signup confirmation mode ---
 
   it('renders OTP form with email and token inputs by default', async () => {
     const wrapper = await mountSuspended(ConfirmPage)
     expect(wrapper.find('input[type="email"]').exists()).toBe(true)
     expect(wrapper.find('input[placeholder="000000"]').exists()).toBe(true)
     expect(wrapper.text()).toContain('Confirm your email')
-  })
-
-  it('does not render the loading spinner by default', async () => {
-    const wrapper = await mountSuspended(ConfirmPage)
-    expect(wrapper.find('.animate-spin').exists()).toBe(false)
   })
 
   it('email field is enabled when no email query param provided', async () => {
@@ -61,67 +47,41 @@ describe('confirm page', () => {
     expect(input.disabled).toBe(true)
   })
 
-  // --- Hash error display ---
-
-  it('renders error state when hash contains an error', async () => {
-    mockRoute.value = { query: {}, hash: '#error=access_denied&error_code=otp_expired&error_description=Token+has+expired' }
+  it('shows "Resend" link pointing to /auth/resend-email in signup mode', async () => {
     const wrapper = await mountSuspended(ConfirmPage)
-    await wrapper.vm.$nextTick()
-    expect(wrapper.text()).toContain('Link expired')
+    const resendLink = wrapper.find('a[href="/auth/resend-email"]')
+    expect(resendLink.exists()).toBe(true)
   })
 
-  it('shows "Resend confirmation email" on hash error', async () => {
-    mockRoute.value = { query: {}, hash: '#error=access_denied&error_code=otp_expired&error_description=Token+has+expired' }
-    const wrapper = await mountSuspended(ConfirmPage)
-    await wrapper.vm.$nextTick()
-    expect(wrapper.text()).toContain('Resend confirmation email')
-  })
+  // --- Recovery mode ---
 
-  // --- Recovery passthrough ---
-
-  it('shows spinner and hides OTP form when type=recovery query param is set', async () => {
+  it('renders recovery heading when type=recovery query param is set', async () => {
     mockRoute.value = { query: { type: 'recovery' }, hash: '' }
     const wrapper = await mountSuspended(ConfirmPage)
-    expect(wrapper.find('.animate-spin').exists()).toBe(true)
-    expect(wrapper.find('input[type="email"]').exists()).toBe(false)
+    expect(wrapper.text()).toContain('Reset your password')
+    expect(wrapper.text()).not.toContain('Confirm your email')
   })
 
-  it('shows recovery spinner when PASSWORD_RECOVERY event fires', async () => {
-    mockOnAuthStateChange.mockImplementation((cb: (event: string) => void) => {
-      cb('PASSWORD_RECOVERY')
-      return { data: { subscription: { unsubscribe: mockUnsubscribe } } }
-    })
+  it('shows recovery code label in recovery mode', async () => {
+    mockRoute.value = { query: { type: 'recovery' }, hash: '' }
     const wrapper = await mountSuspended(ConfirmPage)
-    await wrapper.vm.$nextTick()
-    expect(wrapper.find('.animate-spin').exists()).toBe(true)
+    expect(wrapper.text()).toContain('Recovery code')
   })
 
-  it('calls setSession with hash tokens and navigates to update-password', async () => {
-    mockRoute.value = {
-      query: { type: 'recovery' },
-      hash: '#access_token=tok_abc&refresh_token=ref_xyz&expires_in=3600&token_type=bearer',
-    }
-    await mountSuspended(ConfirmPage)
-    await new Promise(r => setTimeout(r, 0))
-    expect(mockSetSession).toHaveBeenCalledWith({ access_token: 'tok_abc', refresh_token: 'ref_xyz' })
-    expect(mockNavigateTo).toHaveBeenCalledWith('/auth/update-password')
+  it('shows "Request a new code" link pointing to /auth/reset-password in recovery mode', async () => {
+    mockRoute.value = { query: { type: 'recovery' }, hash: '' }
+    const wrapper = await mountSuspended(ConfirmPage)
+    const resendLink = wrapper.find('a[href="/auth/reset-password"]')
+    expect(resendLink.exists()).toBe(true)
   })
 
-  it('does not call setSession when hash contains an error instead of tokens', async () => {
-    mockRoute.value = { query: {}, hash: '#error=access_denied&error_code=otp_expired' }
-    await mountSuspended(ConfirmPage)
-    await new Promise(r => setTimeout(r, 0))
-    expect(mockSetSession).not.toHaveBeenCalled()
+  it('does not show a loading spinner', async () => {
+    mockRoute.value = { query: { type: 'recovery' }, hash: '' }
+    const wrapper = await mountSuspended(ConfirmPage)
+    expect(wrapper.find('.animate-spin').exists()).toBe(false)
   })
 
-  it('does not call setSession when hash is empty', async () => {
-    mockRoute.value = { query: {}, hash: '' }
-    await mountSuspended(ConfirmPage)
-    await new Promise(r => setTimeout(r, 0))
-    expect(mockSetSession).not.toHaveBeenCalled()
-  })
-
-  // --- OTP form submission ---
+  // --- OTP form submission: signup mode ---
 
   it('calls verifyOtp with type email on form submit', async () => {
     const wrapper = await mountSuspended(ConfirmPage)
@@ -137,7 +97,7 @@ describe('confirm page', () => {
     })
   })
 
-  it('navigates to /dashboard on successful verifyOtp', async () => {
+  it('navigates to /dashboard on successful signup verification', async () => {
     mockVerifyOtp.mockResolvedValue({ error: null })
     const wrapper = await mountSuspended(ConfirmPage)
     await wrapper.find('input[type="email"]').setValue('pilot@example.com')
@@ -148,7 +108,36 @@ describe('confirm page', () => {
     expect(mockNavigateTo).toHaveBeenCalledWith('/dashboard')
   })
 
-  it('shows error message and does not navigate when verifyOtp returns an expired OTP error', async () => {
+  // --- OTP form submission: recovery mode ---
+
+  it('calls verifyOtp with type recovery when in recovery mode', async () => {
+    mockRoute.value = { query: { type: 'recovery', email: 'pilot@example.com' }, hash: '' }
+    const wrapper = await mountSuspended(ConfirmPage)
+    await wrapper.find('input[placeholder="000000"]').setValue('654321')
+    await wrapper.find('form').trigger('submit')
+    await wrapper.vm.$nextTick()
+    await new Promise(r => setTimeout(r, 0))
+    expect(mockVerifyOtp).toHaveBeenCalledWith({
+      email: 'pilot@example.com',
+      token: '654321',
+      type: 'recovery',
+    })
+  })
+
+  it('navigates to /auth/update-password on successful recovery verification', async () => {
+    mockRoute.value = { query: { type: 'recovery', email: 'pilot@example.com' }, hash: '' }
+    mockVerifyOtp.mockResolvedValue({ error: null })
+    const wrapper = await mountSuspended(ConfirmPage)
+    await wrapper.find('input[placeholder="000000"]').setValue('654321')
+    await wrapper.find('form').trigger('submit')
+    await wrapper.vm.$nextTick()
+    await new Promise(r => setTimeout(r, 0))
+    expect(mockNavigateTo).toHaveBeenCalledWith('/auth/update-password')
+  })
+
+  // --- Error handling ---
+
+  it('shows error message when verifyOtp returns an expired OTP error', async () => {
     mockVerifyOtp.mockResolvedValue({ error: { message: 'otp has expired', code: 'otp_expired' } })
     const wrapper = await mountSuspended(ConfirmPage)
     await wrapper.find('input[type="email"]').setValue('pilot@example.com')
@@ -158,5 +147,27 @@ describe('confirm page', () => {
     await new Promise(r => setTimeout(r, 0))
     expect(mockNavigateTo).not.toHaveBeenCalled()
     expect(wrapper.text()).toContain('expired or is invalid')
+  })
+
+  it('shows error message when verifyOtp returns an invalid token error', async () => {
+    mockVerifyOtp.mockResolvedValue({ error: { message: 'Token is invalid or has expired' } })
+    const wrapper = await mountSuspended(ConfirmPage)
+    await wrapper.find('input[type="email"]').setValue('pilot@example.com')
+    await wrapper.find('input[placeholder="000000"]').setValue('000000')
+    await wrapper.find('form').trigger('submit')
+    await wrapper.vm.$nextTick()
+    await new Promise(r => setTimeout(r, 0))
+    expect(wrapper.text()).toContain('expired or is invalid')
+  })
+
+  it('shows generic error for non-OTP errors', async () => {
+    mockVerifyOtp.mockResolvedValue({ error: { message: 'Database error' } })
+    const wrapper = await mountSuspended(ConfirmPage)
+    await wrapper.find('input[type="email"]').setValue('pilot@example.com')
+    await wrapper.find('input[placeholder="000000"]').setValue('123456')
+    await wrapper.find('form').trigger('submit')
+    await wrapper.vm.$nextTick()
+    await new Promise(r => setTimeout(r, 0))
+    expect(wrapper.text()).toContain('Database error')
   })
 })

--- a/app/pages/auth/confirm.vue
+++ b/app/pages/auth/confirm.vue
@@ -2,15 +2,16 @@
 import { ConfirmEmailSchema } from '#shared/schemas/auth'
 import type { ConfirmEmailState } from '#shared/schemas/auth'
 
-// Handles two cases:
-// 1. Signup OTP confirmation — user enters 6-digit code from email
-// 2. Password recovery passthrough — hash contains access_token, exchange it and redirect
-//    (Recovery uses implicit flow; tokens arrive in the URL hash, unavailable during SSR)
+// Handles two OTP-based flows:
+// 1. Signup confirmation — user enters 6-digit code from signup email (type: 'email')
+// 2. Recovery confirmation — user enters 6-digit code from recovery email (type: 'recovery')
 
 definePageMeta({ layout: 'auth' })
 
 const supabase = useSupabaseClient()
 const route = useRoute()
+
+const isRecovery = route.query.type === 'recovery'
 
 const state = reactive<ConfirmEmailState>({
   email: (route.query.email as string) ?? '',
@@ -19,50 +20,6 @@ const state = reactive<ConfirmEmailState>({
 const loading = ref(false)
 const error = ref<string | null>(null)
 
-// Hash-based errors (from recovery email redirects gone wrong)
-const errorCode = ref<string | undefined>(undefined)
-const errorDescription = ref<string | undefined>(undefined)
-const errorTitle = computed(() => {
-  if (errorCode.value === 'otp_expired') return 'Link expired'
-  return 'Confirmation failed'
-})
-
-// Recovery passthrough detection
-const isRecovery = ref(route.query.type === 'recovery')
-
-const { data: { subscription } } = supabase.auth.onAuthStateChange((event) => {
-  if (event === 'PASSWORD_RECOVERY') {
-    isRecovery.value = true
-  }
-})
-
-onBeforeUnmount(() => {
-  subscription.unsubscribe()
-})
-
-// All hash-reading is client-only — hash is unavailable during SSR.
-// If this is a recovery link, exchange the tokens and redirect silently.
-onMounted(async () => {
-  const hash = route.hash
-  if (!hash) return
-
-  const params = new URLSearchParams(hash.slice(1))
-
-  if (params.has('error')) {
-    errorCode.value = params.get('error_code') ?? undefined
-    const raw = params.get('error_description')
-    errorDescription.value = raw?.replace(/\+/g, ' ') ?? 'Something went wrong.'
-    return
-  }
-
-  const accessToken = params.get('access_token')
-  const refreshToken = params.get('refresh_token')
-  if (accessToken && refreshToken) {
-    await supabase.auth.setSession({ access_token: accessToken, refresh_token: refreshToken })
-    await navigateTo('/auth/update-password')
-  }
-})
-
 async function onSubmit() {
   loading.value = true
   error.value = null
@@ -70,7 +27,7 @@ async function onSubmit() {
   const { error: verifyError } = await supabase.auth.verifyOtp({
     email: state.email,
     token: state.token,
-    type: 'email',
+    type: isRecovery ? 'recovery' : 'email',
   })
 
   loading.value = false
@@ -86,84 +43,70 @@ async function onSubmit() {
     return
   }
 
-  await navigateTo('/dashboard')
+  if (isRecovery) {
+    await navigateTo('/auth/update-password')
+  }
+  else {
+    await navigateTo('/dashboard')
+  }
 }
 </script>
 
 <template>
   <div>
-    <!-- Hash-based error (broken recovery link etc.) -->
-    <template v-if="errorCode">
+    <h1 class="text-2xl font-bold mb-2 text-center">
+      {{ isRecovery ? 'Reset your password' : 'Confirm your email' }}
+    </h1>
+    <p class="text-sm text-muted text-center mb-6">
+      Enter the 6-digit code we sent to
+      <span v-if="state.email" class="font-medium text-default">{{ state.email }}</span
+      ><span v-else>your email address</span>.
+    </p>
+
+    <UForm :schema="ConfirmEmailSchema" :state="state" class="space-y-4" @submit="onSubmit">
+      <UFormField label="Email" name="email">
+        <UInput
+          v-model="state.email"
+          type="email"
+          placeholder="you@example.com"
+          class="w-full"
+          :disabled="!!(route.query.email as string)"
+        />
+      </UFormField>
+      <UFormField :label="isRecovery ? 'Recovery code' : 'Confirmation code'" name="token">
+        <UInput
+          v-model="state.token"
+          type="text"
+          inputmode="numeric"
+          maxlength="6"
+          placeholder="000000"
+          class="w-full font-mono text-center text-xl tracking-widest"
+        />
+      </UFormField>
+
       <UAlert
+        v-if="error"
         icon="i-lucide-alert-circle"
         color="error"
         variant="soft"
-        :title="errorTitle"
-        :description="errorDescription"
-        class="mb-4"
+        :title="error"
+        class="mt-2"
       />
-      <UButton to="/auth/resend-email" variant="ghost">
-        Resend confirmation email
+
+      <UButton type="submit" class="w-full" :loading="loading">
+        {{ isRecovery ? 'Verify code' : 'Confirm email' }}
       </UButton>
-    </template>
+    </UForm>
 
-    <!-- Recovery passthrough: spinner while setSession + navigateTo runs -->
-    <template v-else-if="isRecovery">
-      <div class="flex items-center justify-center py-8">
-        <UIcon name="i-lucide-loader-circle" class="animate-spin text-4xl text-primary" />
-      </div>
-    </template>
-
-    <!-- Default: OTP input form -->
-    <template v-else>
-      <h1 class="text-2xl font-bold mb-2 text-center">
-        Confirm your email
-      </h1>
-      <p class="text-sm text-muted text-center mb-6">
-        Enter the 6-digit code we sent to
-        <span v-if="state.email" class="font-medium text-default">{{ state.email }}</span
-        ><span v-else>your email address</span>.
-      </p>
-
-      <UForm :schema="ConfirmEmailSchema" :state="state" class="space-y-4" @submit="onSubmit">
-        <UFormField label="Email" name="email">
-          <UInput
-            v-model="state.email"
-            type="email"
-            placeholder="you@example.com"
-            class="w-full"
-            :disabled="!!(route.query.email as string)"
-          />
-        </UFormField>
-        <UFormField label="Confirmation code" name="token">
-          <UInput
-            v-model="state.token"
-            type="text"
-            inputmode="numeric"
-            maxlength="6"
-            placeholder="000000"
-            class="w-full font-mono text-center text-xl tracking-widest"
-          />
-        </UFormField>
-
-        <UAlert
-          v-if="error"
-          icon="i-lucide-alert-circle"
-          color="error"
-          variant="soft"
-          :title="error"
-          class="mt-2"
-        />
-
-        <UButton type="submit" class="w-full" :loading="loading">
-          Confirm email
-        </UButton>
-      </UForm>
-
-      <p class="mt-4 text-center text-sm text-muted">
+    <p class="mt-4 text-center text-sm text-muted">
+      <template v-if="isRecovery">
+        Didn't receive a code?
+        <ULink to="/auth/reset-password" class="text-primary hover:underline">Request a new code</ULink>
+      </template>
+      <template v-else>
         Didn't receive a code?
         <ULink to="/auth/resend-email" class="text-primary hover:underline">Resend</ULink>
-      </p>
-    </template>
+      </template>
+    </p>
   </div>
 </template>

--- a/app/pages/auth/reset-password.vue
+++ b/app/pages/auth/reset-password.vue
@@ -6,18 +6,15 @@ definePageMeta({ layout: 'auth' })
 
 const supabase = useSupabaseClient()
 const loading = ref(false)
-const sent = ref(false)
 
 const state = reactive<ResetPasswordState>({ email: '' })
 
 async function onSubmit() {
   loading.value = true
-  await supabase.auth.resetPasswordForEmail(state.email, {
-    redirectTo: `${window.location.origin}/auth/confirm?type=recovery`,
-  })
+  await supabase.auth.resetPasswordForEmail(state.email)
   loading.value = false
-  // Always show success to prevent email enumeration
-  sent.value = true
+  // Always navigate to confirm page to prevent email enumeration
+  await navigateTo(`/auth/confirm?email=${encodeURIComponent(state.email)}&type=recovery`)
 }
 </script>
 
@@ -25,26 +22,12 @@ async function onSubmit() {
   <div>
     <h1 class="text-2xl font-bold mb-6 text-center">Reset password</h1>
 
-    <template v-if="!sent">
-      <UForm :schema="ResetPasswordSchema" :state="state" class="space-y-4" @submit="onSubmit">
-        <UFormField label="Email" name="email">
-          <UInput v-model="state.email" type="email" placeholder="you@example.com" class="w-full" />
-        </UFormField>
-        <UButton type="submit" class="w-full" :loading="loading">Send reset link</UButton>
-      </UForm>
-    </template>
-
-    <UAlert
-      v-else
-      icon="i-lucide-mail"
-      color="success"
-      variant="soft"
-      title="Check your email"
-      description="If an account exists for that address, we sent a password reset link."
-    />
-    <p v-if="sent" class="mt-3 text-center text-sm text-muted">
-      Don't see it? Check your junk or spam folder.
-    </p>
+    <UForm :schema="ResetPasswordSchema" :state="state" class="space-y-4" @submit="onSubmit">
+      <UFormField label="Email" name="email">
+        <UInput v-model="state.email" type="email" placeholder="you@example.com" class="w-full" />
+      </UFormField>
+      <UButton type="submit" class="w-full" :loading="loading">Send reset code</UButton>
+    </UForm>
 
     <p class="mt-4 text-center text-sm">
       <ULink to="/auth/login" class="text-primary hover:underline">Back to sign in</ULink>

--- a/e2e/auth.spec.ts
+++ b/e2e/auth.spec.ts
@@ -1,6 +1,6 @@
 import { test, expect } from './fixtures/test'
 import { TEST_USERS } from './helpers/auth'
-import { waitForEmail, extractLink, purgeAllMessages } from './helpers/mailpit'
+import { waitForEmail, extractOtpCode, purgeAllMessages } from './helpers/mailpit'
 import { createClient } from '@supabase/supabase-js'
 
 const SUPABASE_URL = 'http://127.0.0.1:54321'
@@ -85,11 +85,11 @@ test.describe('Logout', () => {
 // Password recovery flow
 // ---------------------------------------------------------------------------
 
-test.describe('Password recovery', () => {
+test.describe('Password recovery (OTP)', () => {
   // Use ualUser to avoid interfering with dalUser (used by authenticatedPage fixture)
   const testEmail = TEST_USERS.ualUser.email
 
-  test('request → email → set new password → dashboard', async ({ page, goto }) => {
+  test('request → OTP code → set new password → dashboard', async ({ page, goto }) => {
     await purgeAllMessages()
 
     // Step 1: Request password reset
@@ -97,28 +97,30 @@ test.describe('Password recovery', () => {
     await page.getByLabel('Email').fill(testEmail)
     await page.getByRole('button', { name: /reset|send/i }).click()
 
-    // Should show success alert (UAlert renders title in [data-slot="title"])
-    await expect(page.locator('[data-slot="title"]').filter({ hasText: 'Check your email' })).toBeVisible({ timeout: 5000 })
+    // Should navigate to confirm page with recovery type
+    await expect(page).toHaveURL(/\/auth\/confirm.*type=recovery/, { timeout: 5000 })
+    await expect(page.getByRole('heading', { name: 'Reset your password' })).toBeVisible()
 
-    // Step 2: Get the recovery email from Mailpit
+    // Step 2: Get the recovery OTP from Mailpit
     const email = await waitForEmail(testEmail, { subject: 'Reset' })
-    const link = extractLink(email.HTML)
-    expect(link).toBeTruthy()
+    const otpCode = extractOtpCode(email.HTML)
+    expect(otpCode).toMatch(/^\d{6}$/)
 
-    // Step 3: Click the recovery link → Supabase verify → /auth/confirm → /auth/update-password
-    await page.goto(link)
+    // Step 3: Enter the OTP code
+    await page.getByLabel('Recovery code').fill(otpCode)
+    await page.getByRole('button', { name: /verify/i }).click()
+
+    // Step 4: Should redirect to update-password
     await expect(page).toHaveURL(/\/auth\/update-password/, { timeout: 10000 })
-
-    // Wait for the page to be fully rendered before interacting
     await expect(page.getByRole('heading', { name: 'Set new password' })).toBeVisible()
 
-    // Step 4: Set a new password (must differ from old — Supabase rejects same-password updates)
+    // Step 5: Set a new password (must differ from old — Supabase rejects same-password updates)
     const tempPassword = 'TempNewPass1234!'
     await page.getByLabel('New password').fill(tempPassword)
     await page.getByLabel('Confirm password').fill(tempPassword)
     await page.getByRole('button', { name: /update password/i }).click()
 
-    // Step 5: Should redirect to dashboard
+    // Step 6: Should redirect to dashboard
     await expect(page).toHaveURL('http://localhost:3000/dashboard', { timeout: 15000 })
 
     // Restore original password so future test runs work

--- a/server/api/admin/reset-password.post.ts
+++ b/server/api/admin/reset-password.post.ts
@@ -17,10 +17,7 @@ export default defineEventHandler(async (event) => {
     throw createError({ statusCode: 404, statusMessage: 'User not found' })
   }
 
-  const origin = getRequestURL(event).origin
-  const { error } = await client.auth.resetPasswordForEmail(userData.user.email, {
-    redirectTo: `${origin}/auth/confirm?type=recovery`,
-  })
+  const { error } = await client.auth.resetPasswordForEmail(userData.user.email)
 
   if (error) {
     log.error('Failed to send recovery email', { userId, error: error.message })

--- a/supabase/config.toml
+++ b/supabase/config.toml
@@ -27,14 +27,8 @@ enabled = true
 enable_signup = true
 site_url = "http://localhost:3000"
 additional_redirect_urls = [
-  "http://localhost:3000/auth/confirm",
-  "http://127.0.0.1:3000/auth/confirm",
-  "http://localhost:3000/auth/update-password",
-  "http://127.0.0.1:3000/auth/update-password",
   "http://localhost:3000/auth/accept-invite",
   "http://127.0.0.1:3000/auth/accept-invite",
-  "https://seniorityguru.com/auth/confirm",
-  "https://seniorityguru.com/auth/update-password",
   "https://seniorityguru.com/auth/accept-invite"
 ]
 jwt_expiry = 3600

--- a/supabase/templates/recovery.html
+++ b/supabase/templates/recovery.html
@@ -1,25 +1,19 @@
 <!DOCTYPE html>
 <html>
-
 <head>
   <meta charset="utf-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
   <title>Reset Your Password</title>
 </head>
-
-<body
-  style="margin:0; padding:0; background-color:#f4f4f5; font-family:-apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Helvetica, Arial, sans-serif;">
-  <table role="presentation" width="100%" cellpadding="0" cellspacing="0"
-    style="background-color:#f4f4f5; padding:40px 20px;">
+<body style="margin:0; padding:0; background-color:#f4f4f5; font-family:-apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Helvetica, Arial, sans-serif;">
+  <table role="presentation" width="100%" cellpadding="0" cellspacing="0" style="background-color:#f4f4f5; padding:40px 20px;">
     <tr>
       <td align="center">
-        <table role="presentation" width="480" cellpadding="0" cellspacing="0"
-          style="background-color:#ffffff; border-radius:8px; overflow:hidden;">
+        <table role="presentation" width="480" cellpadding="0" cellspacing="0" style="background-color:#ffffff; border-radius:8px; overflow:hidden;">
           <!-- Header -->
           <tr>
             <td style="background-color:#1e293b; padding:24px 32px; text-align:center;">
-              <h1 style="margin:0; font-size:22px; font-weight:700; color:#ffffff; letter-spacing:-0.5px;">SeniorityGuru
-              </h1>
+              <h1 style="margin:0; font-size:22px; font-weight:700; color:#ffffff; letter-spacing:-0.5px;">SeniorityGuru</h1>
             </td>
           </tr>
           <!-- Body -->
@@ -27,22 +21,30 @@
             <td style="padding:32px;">
               <h2 style="margin:0 0 16px; font-size:20px; font-weight:600; color:#1e293b;">Need a new password?</h2>
               <p style="margin:0 0 24px; font-size:15px; line-height:1.6; color:#475569;">
-                No problem! Click the button below to choose a new password for your SeniorityGuru account.
+                No problem! Enter the code below to reset your SeniorityGuru password.
               </p>
+              <!-- OTP Code -->
+              <table role="presentation" cellpadding="0" cellspacing="0" style="margin:0 auto 24px;">
+                <tr>
+                  <td style="background-color:#f1f5f9; border:2px dashed #cbd5e1; border-radius:8px; padding:16px 32px; text-align:center;">
+                    <p style="margin:0 0 4px; font-size:12px; font-weight:600; color:#94a3b8; letter-spacing:0.1em; text-transform:uppercase;">Your recovery code</p>
+                    <p style="margin:0; font-size:32px; font-weight:700; color:#1e293b; letter-spacing:0.15em; font-family:monospace;">{{ .Token }}</p>
+                  </td>
+                </tr>
+              </table>
               <!-- CTA -->
               <table role="presentation" cellpadding="0" cellspacing="0" style="margin:0 auto;">
                 <tr>
                   <td style="border-radius:6px; background-color:#2563eb;">
-                    <a href="{{ .ConfirmationURL }}" target="_blank"
-                      style="display:inline-block; padding:12px 32px; font-size:15px; font-weight:600; color:#ffffff; text-decoration:none;">
-                      Reset Password
+                    <a href="{{ .SiteURL }}/auth/confirm?type=recovery" target="_blank" style="display:inline-block; padding:12px 32px; font-size:15px; font-weight:600; color:#ffffff; text-decoration:none;">
+                      Enter my code
                     </a>
                   </td>
                 </tr>
               </table>
               <p style="margin:24px 0 0; font-size:13px; line-height:1.5; color:#94a3b8;">
-                If the button doesn't work, copy and paste this link into your browser:<br />
-                <a href="{{ .ConfirmationURL }}" style="color:#2563eb; word-break:break-all;">{{ .ConfirmationURL }}</a>
+                If the button doesn't work, go to <strong>{{ .SiteURL }}/auth/confirm?type=recovery</strong> and enter the code above.<br />
+                This code expires in 1 hour.
               </p>
             </td>
           </tr>
@@ -59,5 +61,4 @@
     </tr>
   </table>
 </body>
-
 </html>


### PR DESCRIPTION
## Summary
- Recovery email now sends a 6-digit OTP code instead of a PKCE link that caused infinite spinner
- `confirm.vue` rewritten as pure OTP form — all hash parsing, `exchangeCodeForSession`, `setSession`, and `onAuthStateChange(PASSWORD_RECOVERY)` removed
- `reset-password.vue` navigates to `/auth/confirm?type=recovery` instead of showing inline success
- All three auth flows (signup, recovery, invite) now use the same OTP pattern

## Action required
Update the **Reset Password** email template in the Supabase dashboard with the content from `supabase/templates/recovery.html`

## Test plan
- [x] 15 unit tests for confirm.vue (both signup and recovery modes)
- [x] E2E password recovery test updated to use OTP extraction
- [x] Lint: 0 errors
- [x] Typecheck: clean
- [x] All 676 tests pass