### PR TITLE
Canonicalize employee numbers, normalize dashboard list IDs, and simplify list fetch behavior

### DIFF
--- a/app/composables/seniority/modules/useSeniorityCore.test.ts
+++ b/app/composables/seniority/modules/useSeniorityCore.test.ts
@@ -61,6 +61,14 @@ describe('useSeniorityCore', () => {
     expect(lens.value).toBeNull()
   })
 
+  it('matches user by canonicalized employee number', () => {
+    mockStore.entries = [makeEntry({ seniority_number: 1, employee_number: ' 123 ', retire_date: '2045-01-01' })]
+    mockUserStore.employeeNumber = '00123'
+    const { hasAnchor, userEntry } = useSeniorityCore()
+    expect(hasAnchor.value).toBe(true)
+    expect(userEntry.value?.employee_number).toBe(' 123 ')
+  })
+
   it('hasData/hasAnchor readiness signals are correct', () => {
     mockStore.entries = [makeEntry({ employee_number: 'E1' })]
     mockUserStore.employeeNumber = 'E1'

--- a/app/composables/seniority/modules/useSeniorityCore.ts
+++ b/app/composables/seniority/modules/useSeniorityCore.ts
@@ -6,6 +6,7 @@ import { computeRetireDate, todayISO } from '~/utils/date'
 import { useSeniorityStore } from '~/stores/seniority'
 import { useUserStore } from '~/stores/user'
 import { createLogger } from '~/utils/logger'
+import { canonicalizeEmployeeNumber } from '~/utils/schemas/seniority-list'
 
 const log = createLogger('seniority-core')
 
@@ -120,7 +121,8 @@ export function useSeniorityCore() {
   const realUserFound = computed(() => {
     const empNum = userStore.employeeNumber
     if (!empNum) return false
-    return seniorityStore.entries.some(e => e.employee_number === empNum)
+    const canonicalEmpNum = canonicalizeEmployeeNumber(empNum)
+    return seniorityStore.entries.some(e => canonicalizeEmployeeNumber(e.employee_number) === canonicalEmpNum)
   })
 
   const retireDate = computed(() => {
@@ -184,7 +186,8 @@ export function useSeniorityCore() {
     _userEntry = computed<SeniorityEntry | undefined>(() => {
       const empNum = userStore.employeeNumber
       if (!empNum) return undefined
-      return seniorityStore.entries.find(e => e.employee_number === empNum)
+      const canonicalEmpNum = canonicalizeEmployeeNumber(empNum)
+      return seniorityStore.entries.find(e => canonicalizeEmployeeNumber(e.employee_number) === canonicalEmpNum)
     })
   }
 

--- a/app/composables/seniority/modules/useSeniorityLists.test.ts
+++ b/app/composables/seniority/modules/useSeniorityLists.test.ts
@@ -47,18 +47,11 @@ describe('useSeniorityLists', () => {
     expect(listOptions.value[0]!.label).toBe('2025-06-01')
   })
 
-  it('fetchLists calls store.fetchLists when lists are empty', async () => {
-    mockStore.lists = []
-    const { fetchLists } = useSeniorityLists()
-    await fetchLists()
-    expect(mockStore.fetchLists).toHaveBeenCalledOnce()
-  })
-
-  it('fetchLists skips store call when lists already loaded', async () => {
+  it('fetchLists always delegates to store.fetchLists', async () => {
     mockStore.lists = [{ id: 1, effectiveDate: '2025-01-01', createdAt: '' }]
     const { fetchLists } = useSeniorityLists()
     await fetchLists()
-    expect(mockStore.fetchLists).not.toHaveBeenCalled()
+    expect(mockStore.fetchLists).toHaveBeenCalledOnce()
   })
 
   it('deleteList delegates to store.deleteList', async () => {

--- a/app/composables/seniority/modules/useSeniorityLists.ts
+++ b/app/composables/seniority/modules/useSeniorityLists.ts
@@ -17,7 +17,7 @@ export function useSeniorityLists() {
   )
 
   async function fetchLists() {
-    if (!store.lists.length) await store.fetchLists()
+    await store.fetchLists()
   }
 
   async function deleteList(id: number) {

--- a/app/composables/seniority/upload/_useConfirm.test.ts
+++ b/app/composables/seniority/upload/_useConfirm.test.ts
@@ -67,6 +67,24 @@ describe('_useConfirm', () => {
     )
   })
 
+  it('canonicalizes employee numbers before persisting', async () => {
+    const confirm = createConfirm()
+    confirm.effectiveDate.value = { toString: () => '2025-01-01' } as never
+
+    const entries = [
+      makeDomainEntry({ seniority_number: 1, employee_number: ' 00123 ', seat: 'CA', base: 'LAX', fleet: 'B737', hire_date: '2010-01-01', retire_date: '2040-01-01' }),
+    ]
+
+    await confirm.save(entries)
+
+    expect(mockStore.addList).toHaveBeenCalledWith(
+      expect.any(Object),
+      expect.arrayContaining([
+        expect.objectContaining({ employeeNumber: '123' }),
+      ]),
+    )
+  })
+
   it('sets error on save failure and re-throws', async () => {
     mockStore.addList.mockRejectedValue(new Error('DB full'))
     const error = ref<string | null>(null)

--- a/app/composables/seniority/upload/_useConfirm.ts
+++ b/app/composables/seniority/upload/_useConfirm.ts
@@ -1,6 +1,7 @@
 import type { DateValue } from 'reka-ui'
 import type { ConfirmPhase, ConfirmPhaseOptions } from './types'
 import type { SeniorityEntry } from '~/utils/schemas/seniority-list'
+import { canonicalizeEmployeeNumber } from '~/utils/schemas/seniority-list'
 import { useSeniorityStore } from '~/stores/seniority'
 import { createLogger } from '~/utils/logger'
 
@@ -20,7 +21,7 @@ export function _useConfirm(opts: ConfirmPhaseOptions): ConfirmPhase & { _reset:
       const store = useSeniorityStore()
       const localEntries = (entries as SeniorityEntry[]).map(e => ({
         seniorityNumber: e.seniority_number,
-        employeeNumber: e.employee_number,
+        employeeNumber: canonicalizeEmployeeNumber(String(e.employee_number ?? '')),
         name: e.name ?? null,
         seat: e.seat,
         base: e.base,

--- a/app/composables/useUser.test.ts
+++ b/app/composables/useUser.test.ts
@@ -87,6 +87,14 @@ describe('useUser', () => {
       const user = useUser()
       expect(user.entry.value).toBeUndefined()
     })
+
+    it('matches entry with canonicalized employee number', async () => {
+      mockUserStore.employeeNumber = '00123'
+      mockSeniorityEntries.push({ employee_number: ' 123 ', seniority_number: 1, seat: 'CA', base: 'JFK', fleet: '737', hire_date: '2010-01-01', retire_date: '2040-01-01' })
+      const { useUser } = await import('./useUser')
+      const user = useUser()
+      expect(user.entry.value?.employee_number).toBe(' 123 ')
+    })
   })
 
   describe('loadPreferences', () => {

--- a/app/composables/useUser.ts
+++ b/app/composables/useUser.ts
@@ -1,6 +1,7 @@
 import { useUserStore } from '~/stores/user'
 import { useSeniorityStore } from '~/stores/seniority'
 import type { PreferenceMap } from '~/utils/preferences'
+import { canonicalizeEmployeeNumber } from '~/utils/schemas/seniority-list'
 
 export function useUser() {
   const store = useUserStore()
@@ -14,7 +15,8 @@ export function useUser() {
   const entry = computed(() => {
     const empNum = store.employeeNumber
     if (!empNum) return undefined
-    return seniorityStore.entries.find((e) => e.employee_number === empNum)
+    const canonicalEmpNum = canonicalizeEmployeeNumber(empNum)
+    return seniorityStore.entries.find((e) => canonicalizeEmployeeNumber(e.employee_number) === canonicalEmpNum)
   })
 
   /**

--- a/app/pages/dashboard.test.ts
+++ b/app/pages/dashboard.test.ts
@@ -144,6 +144,22 @@ describe('dashboard.vue — route-synced ref / watcher race condition', () => {
     expect(mockFetchEntries).toHaveBeenCalledWith(OLD_ID)
   })
 
+  it('falls back to latest list when URL list id is stale', async () => {
+    const STALE_ID = 999
+    const LATEST_ID = 77
+
+    mockRouteQuery.value = { list: String(STALE_ID) }
+    mockFetchLists.mockImplementation(() => {
+      mockLists.value = [makeList(LATEST_ID)]
+    })
+
+    const DashboardPage = await import('./dashboard.vue')
+    await mountSuspended(DashboardPage.default)
+
+    expect(mockFetchEntries).toHaveBeenCalledTimes(1)
+    expect(mockFetchEntries).toHaveBeenCalledWith(LATEST_ID)
+  })
+
   it('calls navigateTo when selectedListId changes after mount', async () => {
     const LIST_A = 1
     const LIST_B = 2
@@ -155,6 +171,10 @@ describe('dashboard.vue — route-synced ref / watcher race condition', () => {
 
     const DashboardPage = await import('./dashboard.vue')
     const wrapper = await mountSuspended(DashboardPage.default)
+
+    await vi.waitFor(() => {
+      expect(mockFetchEntries).toHaveBeenCalledWith(LIST_A)
+    })
 
     // Clear navigateTo calls from mount
     mockNavigateTo.mockClear()
@@ -172,5 +192,32 @@ describe('dashboard.vue — route-synced ref / watcher race condition', () => {
       expect.objectContaining({ query: expect.objectContaining({ list: String(LIST_B) }) }),
       expect.objectContaining({ replace: true }),
     )
+  })
+
+  it('normalizes string dropdown ids before fetching entries', async () => {
+    const LIST_A = 1
+    const LIST_B = 2
+
+    mockRouteQuery.value = { list: String(LIST_A) }
+    mockFetchLists.mockImplementation(() => {
+      mockLists.value = [makeList(LIST_B), makeList(LIST_A)]
+    })
+
+    const DashboardPage = await import('./dashboard.vue')
+    const wrapper = await mountSuspended(DashboardPage.default)
+
+    await vi.waitFor(() => {
+      expect(mockFetchEntries).toHaveBeenCalledWith(LIST_A)
+    })
+
+    mockFetchEntries.mockClear()
+
+    const vm = wrapper.vm as unknown as { selectedListId: string | number }
+    vm.selectedListId = String(LIST_B)
+
+    await nextTick()
+    await nextTick()
+
+    expect(mockFetchEntries).toHaveBeenCalledWith(LIST_B)
   })
 })

--- a/app/pages/dashboard.vue
+++ b/app/pages/dashboard.vue
@@ -3,12 +3,14 @@ import { useSeniorityCore, useStanding, useSeniorityLists } from '~/composables/
 import { useDashboardTabs } from '~/composables/useDashboardTabs';
 import { useDemoBanner } from '~/composables/useDemoBanner';
 import { DEFAULT_TAB } from '~/utils/dashboard-tabs';
+import { createLogger } from '~/utils/logger';
 
 definePageMeta({
   layout: 'dashboard',
 });
 
 const route = useRoute();
+const log = createLogger('dashboard-page')
 
 const { activeTab, tabs } = useDashboardTabs();
 
@@ -22,12 +24,19 @@ watch(activeTab, (tab) => {
 const { lists, fetchLists, fetchEntries } = useSeniorityLists();
 const { employeeNumber, loadPreferences } = useUser();
 const loading = ref(true);
+const initializing = ref(true);
 
 // Initialize synchronously from the URL so the watcher never sees this as a
 // "change" — the watcher is lazy by default and won't fire on the initial value.
 const selectedListId = ref<number | undefined>(
-  route.query.list ? Number(route.query.list) : undefined,
+  normalizeListId(route.query.list),
 );
+
+function normalizeListId(value: unknown): number | undefined {
+  const raw = Array.isArray(value) ? value[0] : value
+  const n = typeof raw === 'number' ? raw : Number(raw)
+  return Number.isFinite(n) && n > 0 ? n : undefined
+}
 
 const listOptions = computed(() =>
   lists.value.map((l, i) => ({
@@ -74,10 +83,13 @@ const panelUi = computed(() => ({
 // Watcher fires ONLY for user-initiated dropdown changes after mount.
 // When onMounted sets the default value, oldId is undefined → guard skips it.
 watch(selectedListId, async (id, oldId) => {
-  if (!id || !oldId) return;
+  const normalizedId = normalizeListId(id)
+  const normalizedOldId = normalizeListId(oldId)
+  if (initializing.value || !normalizedId || !normalizedOldId || normalizedId === normalizedOldId) return;
   loading.value = true;
-  await fetchEntries(id);
-  const query: Record<string, string> = { list: String(id) };
+  log.info('Loading entries for selected list', { listId: normalizedId, previousListId: normalizedOldId })
+  await fetchEntries(normalizedId);
+  const query: Record<string, string> = { list: String(normalizedId) };
   if (activeTab.value !== DEFAULT_TAB) query.tab = activeTab.value;
   await navigateTo({ path: '/dashboard', query }, { replace: true });
   loading.value = false;
@@ -86,17 +98,31 @@ watch(selectedListId, async (id, oldId) => {
 onMounted(async () => {
   await loadPreferences();
   await fetchLists();
+  log.info('Dashboard lists loaded', {
+    listCount: lists.value.length,
+    routeListId: route.query.list ?? null,
+    selectedListId: selectedListId.value ?? null,
+  })
 
-  // Set a default if the URL had no ?list= param.
-  // This fires the watcher but oldId=undefined → the guard catches it.
-  if (!selectedListId.value) {
+  // Route query may contain a stale list id (deleted/old session).
+  // Fall back to newest available list in that case.
+  const normalizedSelectedListId = normalizeListId(selectedListId.value)
+  if (!normalizedSelectedListId || !lists.value.some(l => l.id === normalizedSelectedListId)) {
     selectedListId.value = lists.value[0]?.id ?? undefined;
+    log.info('Selected list fallback applied', { listId: selectedListId.value ?? null })
+  } else if (selectedListId.value !== normalizedSelectedListId) {
+    selectedListId.value = normalizedSelectedListId
   }
 
   if (selectedListId.value) {
-    await fetchEntries(selectedListId.value);
+    const listId = normalizeListId(selectedListId.value)
+    if (listId) {
+      log.info('Initial entries load', { listId })
+      await fetchEntries(listId);
+    }
   }
 
+  initializing.value = false;
   loading.value = false;
 });
 </script>

--- a/app/stores/seniority.ts
+++ b/app/stores/seniority.ts
@@ -70,11 +70,12 @@ export const useSeniorityStore = defineStore('seniority', () => {
     entriesError.value = null
     entries.value = []
     currentListId.value = listId
+    log.info('Fetching entries for list', { listId })
 
     try {
       const localEntries = await db.seniorityEntries.where('listId').equals(listId).toArray()
       entries.value = localEntries.map(localEntryToSeniorityEntry)
-      log.debug('Entries fetched', { listId, count: entries.value.length })
+      log.info('Entries fetched', { listId, count: entries.value.length })
     }
     catch (e: unknown) {
       const message = e instanceof Error ? e.message : 'Failed to fetch entries'

--- a/app/stores/user.test.ts
+++ b/app/stores/user.test.ts
@@ -43,6 +43,21 @@ describe('user store (Dexie preferences)', () => {
       expect(store.employeeNumber).toBe('99999')
     })
 
+    it('canonicalizes employeeNumber loaded from preferences table', async () => {
+      mockDb.preferences.get.mockImplementation(async (key: string) => {
+        if (key === 'employeeNumber') return { key: 'employeeNumber', value: ' 00123 ' }
+        return undefined
+      })
+
+      const { useUserStore } = await import('./user')
+      const store = useUserStore()
+      await store.clearPreferences()
+
+      await store.loadPreferences()
+
+      expect(store.employeeNumber).toBe('123')
+    })
+
     it('loads retirementAge from preferences table', async () => {
       mockDb.preferences.get.mockImplementation(async (key: string) => {
         if (key === 'retirementAge') return { key: 'retirementAge', value: '60' }
@@ -105,6 +120,16 @@ describe('user store (Dexie preferences)', () => {
       await store.savePreference('employeeNumber', '12345')
 
       expect(mockDb.preferences.put).toHaveBeenCalledWith({ key: 'employeeNumber', value: '12345' })
+    })
+
+    it('canonicalizes employeeNumber before saving to preferences', async () => {
+      const { useUserStore } = await import('./user')
+      const store = useUserStore()
+
+      await store.savePreference('employeeNumber', ' 00123 ')
+
+      expect(mockDb.preferences.put).toHaveBeenCalledWith({ key: 'employeeNumber', value: '123' })
+      expect(store.employeeNumber).toBe('123')
     })
 
     it('updates employeeNumber ref when key is employeeNumber', async () => {

--- a/app/stores/user.ts
+++ b/app/stores/user.ts
@@ -4,6 +4,7 @@ import { createLogger } from '~/utils/logger'
 import { PREFERENCE_SERIALIZERS, PREFERENCE_DESERIALIZERS } from '~/utils/preferences'
 import type { PreferenceMap } from '~/utils/preferences'
 import { emitHook } from '~/utils/hooks'
+import { canonicalizeEmployeeNumber } from '~/utils/schemas/seniority-list'
 
 const log = createLogger('user-store')
 
@@ -23,7 +24,7 @@ export const useUserStore = defineStore('user', () => {
         db.preferences.get('retirementAge'),
       ])
 
-      employeeNumber.value = empPref ? empPref.value : null
+      employeeNumber.value = empPref ? canonicalizeEmployeeNumber(empPref.value) : null
       retirementAge.value = agePref ? Number(agePref.value) : 65
 
       log.debug('Preferences loaded', { employeeNumber: employeeNumber.value, retirementAge: retirementAge.value })
@@ -42,7 +43,7 @@ export const useUserStore = defineStore('user', () => {
     await db.preferences.put({ key, value: serialized })
 
     if (key === 'employeeNumber') {
-      employeeNumber.value = value as string
+      employeeNumber.value = canonicalizeEmployeeNumber(value as string)
     }
     else if (key === 'retirementAge') {
       retirementAge.value = value as number

--- a/app/utils/preferences.ts
+++ b/app/utils/preferences.ts
@@ -1,3 +1,5 @@
+import { canonicalizeEmployeeNumber } from './schemas/seniority-list'
+
 /** Stored shape of the new-hire configuration preference (key: 'growthConfig'). */
 export interface NewHireConfig {
   birthDate: string | null
@@ -19,7 +21,7 @@ export interface PreferenceMap {
 
 /** Serializes a typed preference value to the string stored in Dexie. */
 export const PREFERENCE_SERIALIZERS: { [K in keyof PreferenceMap]: (v: PreferenceMap[K]) => string } = {
-  employeeNumber: (v) => v,
+  employeeNumber: (v) => canonicalizeEmployeeNumber(v),
   retirementAge: (v) => String(v),
   newHireEnabled: (v) => String(v),
   growthConfig: (v) => JSON.stringify(v),
@@ -30,7 +32,7 @@ export const PREFERENCE_SERIALIZERS: { [K in keyof PreferenceMap]: (v: Preferenc
 
 /** Deserializes a raw Dexie string back to the typed preference value. */
 export const PREFERENCE_DESERIALIZERS: { [K in keyof PreferenceMap]: (raw: string) => PreferenceMap[K] } = {
-  employeeNumber: (raw) => raw,
+  employeeNumber: (raw) => canonicalizeEmployeeNumber(raw),
   retirementAge: (raw) => Number(raw),
   newHireEnabled: (raw) => raw === 'true',
   growthConfig: (raw) => JSON.parse(raw) as NewHireConfig,

--- a/app/utils/schemas/seniority-list.ts
+++ b/app/utils/schemas/seniority-list.ts
@@ -10,6 +10,11 @@ export function normalizeEmployeeNumber(value: string): string {
   return value
 }
 
+/** Trim whitespace and normalize numeric leading-zero formatting. */
+export function canonicalizeEmployeeNumber(value: string): string {
+  return normalizeEmployeeNumber(value.trim())
+}
+
 export const SeniorityEntrySchema = z.object({
   seniority_number: z.number().int().positive(),
   employee_number: z.string().min(1),
@@ -21,4 +26,3 @@ export const SeniorityEntrySchema = z.object({
   retire_date: z.string().regex(ISO_DATE_REGEX, 'Invalid date format'),
 })
 export type SeniorityEntry = z.infer<typeof SeniorityEntrySchema>
-


### PR DESCRIPTION
### Motivation
- Ensure employee numbers are compared and persisted consistently by trimming whitespace and normalizing numeric formatting (e.g. leading zeros). 
- Make dashboard list id handling robust to stale or string-valued route params and avoid accidental watcher-triggered fetches on initialization. 
- Simplify list fetching behavior so callers always delegate to the store and improve logging for entry fetches.

### Description
- Add `canonicalizeEmployeeNumber` (uses `normalizeEmployeeNumber` with `trim`) in `utils/schemas/seniority-list.ts` and apply it to preference serialization/deserialization in `utils/preferences.ts`. 
- Canonicalize employee numbers when loading/saving preferences in `stores/user.ts`, and when matching entries in `useUser.ts` and `useSeniorityCore.ts`. 
- Canonicalize employee numbers before persisting upload entries in `_useConfirm.ts` so stored `employeeNumber` values are normalized. 
- Normalize route/list ids in `pages/dashboard.vue` via a new `normalizeListId` helper, add an `initializing` guard to avoid watcher races, fall back to the latest list when the URL list id is stale, and add informational logging. 
- Always call `store.fetchLists()` from `useSeniorityLists.ts` (remove short-circuit) and change some `fetchEntries` logging levels in `stores/seniority.ts`. 
- Update and add unit tests to cover canonicalization and dashboard/list-id behaviors in `useSeniorityCore.test.ts`, `_useConfirm.test.ts`, `useUser.test.ts`, `stores/user.test.ts`, `pages/dashboard.test.ts`, and `useSeniorityLists.test.ts`.

### Testing
- Ran the unit tests touching the modified areas, including `useSeniorityCore`, `_useConfirm`, `useUser`, `stores/user`, `dashboard` page tests, and `useSeniorityLists` tests, and they all succeeded. 
- Verified new tests asserting canonicalization of employee numbers and dashboard fallback/normalization behavior pass. 
- Verified updated tests for delegated list fetching and entry persistence pass.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e7eac97a348322b573d672af579478)