### PR TITLE
Structured validation for seniority upload, extract mapping defaults, and require validated entries on save

### DIFF
--- a/app/composables/seniority/upload/_useColumnMapping.ts
+++ b/app/composables/seniority/upload/_useColumnMapping.ts
@@ -1,25 +1,10 @@
 import type { MappingPhase, MappingPhaseOptions } from './types'
-import type { ColumnMap, MappingOptions } from '~/utils/parse-spreadsheet'
+import type { MappingOptions } from '~/utils/parse-spreadsheet'
 import { applyColumnMapAsync } from '~/utils/parse-spreadsheet'
 import { createLogger } from '~/utils/logger'
+import { DEFAULT_COLUMN_MAP, DEFAULT_MAPPING_OPTIONS } from './defaults'
 
 const log = createLogger('upload:mapping')
-
-const DEFAULT_COLUMN_MAP: ColumnMap = {
-  seniority_number: -1,
-  employee_number: -1,
-  seat: -1,
-  base: -1,
-  fleet: -1,
-  name: -1,
-  hire_date: -1,
-  retire_date: -1,
-}
-
-const DEFAULT_MAPPING_OPTIONS: MappingOptions = {
-  nameMode: 'single',
-  retireMode: 'direct',
-}
 
 export function _useColumnMapping(opts: MappingPhaseOptions): MappingPhase & { _reset: () => void } {
   const mappingOptions = ref<MappingOptions>({ ...DEFAULT_MAPPING_OPTIONS })

--- a/app/composables/seniority/upload/_useConfirm.ts
+++ b/app/composables/seniority/upload/_useConfirm.ts
@@ -12,16 +12,16 @@ export function _useConfirm(opts: ConfirmPhaseOptions): ConfirmPhase & { _reset:
   const title = ref('')
   const saving = ref(false)
 
-  async function save(entries: Partial<SeniorityEntry>[]): Promise<number> {
+  async function save(entries: SeniorityEntry[]): Promise<number> {
     saving.value = true
     opts.error.value = null
     log.info('Upload started', { entryCount: entries.length, effectiveDate: effectiveDate.value?.toString() })
 
     try {
-      createSnapshot(entries as SeniorityEntry[])
+      createSnapshot(entries)
 
       const store = useSeniorityStore()
-      const localEntries = (entries as SeniorityEntry[]).map(e => ({
+      const localEntries = entries.map(e => ({
         seniorityNumber: e.seniority_number,
         employeeNumber: e.employee_number,
         name: e.name ?? null,

--- a/app/composables/seniority/upload/_useReview.ts
+++ b/app/composables/seniority/upload/_useReview.ts
@@ -1,16 +1,31 @@
 import type { ReviewPhase, ReviewPhaseOptions } from './types'
 import type { SeniorityEntry } from '~/utils/schemas/seniority-list'
 import { SeniorityEntrySchema } from '~/utils/schemas/seniority-list'
-import { computeStructuralErrors } from '~/utils/validate-entries'
+import { computeStructuralIssues, type ValidationIssue } from '~/utils/validate-entries'
 import { BATCH_SIZE } from '~/utils/parse-spreadsheet'
 import { createLogger } from '~/utils/logger'
 
 const log = createLogger('upload:review')
 
-function isStructuralError(msg: string): boolean {
-  return msg.startsWith('seniority_number: Duplicate') ||
-    msg.startsWith('seniority_number: Non-contiguous') ||
-    msg.startsWith('employee_number: Duplicate')
+function formatSchemaIssues(entry: Partial<SeniorityEntry>): ValidationIssue[] {
+  const result = SeniorityEntrySchema.safeParse(entry)
+  if (result.success) return []
+  return result.error.issues.map(issue => ({
+    code: 'schema_violation',
+    field: issue.path.join('.'),
+    rowIndex: -1,
+    message: issue.message,
+  }))
+}
+
+function formatIssueMessage(issue: ValidationIssue): string {
+  return `${issue.field}: ${issue.message}`
+}
+
+function isStructuralMessage(raw: string): boolean {
+  return raw.startsWith('seniority_number: Duplicate seniority number')
+    || raw.startsWith('seniority_number: Non-contiguous sequence')
+    || raw.startsWith('employee_number: Duplicate employee number')
 }
 
 export function _useReview(opts: ReviewPhaseOptions): ReviewPhase & { _reset: () => void } {
@@ -24,16 +39,14 @@ export function _useReview(opts: ReviewPhaseOptions): ReviewPhase & { _reset: ()
     opts.progress.report('validating', 0, opts.entries.value.length)
 
     const total = opts.entries.value.length
-    const schemaErrors = new Map<number, string[]>()
+    const schemaIssues = new Map<number, ValidationIssue[]>()
 
     for (let i = 0; i < total; i += BATCH_SIZE) {
       const end = Math.min(i + BATCH_SIZE, total)
       for (let j = i; j < end; j++) {
         const entry = opts.entries.value[j]!
-        const result = SeniorityEntrySchema.safeParse(entry)
-        if (!result.success) {
-          schemaErrors.set(j, result.error.issues.map(issue => `${issue.path.join('.')}: ${issue.message}`))
-        }
+        const entryIssues = formatSchemaIssues(entry).map(issue => ({ ...issue, rowIndex: j }))
+        if (entryIssues.length > 0) schemaIssues.set(j, entryIssues)
       }
       opts.progress.report('validating', end, total)
       if (end < total) {
@@ -41,35 +54,35 @@ export function _useReview(opts: ReviewPhaseOptions): ReviewPhase & { _reset: ()
       }
     }
 
-    const structural = computeStructuralErrors(opts.entries.value)
+    const structural = computeStructuralIssues(opts.entries.value)
 
-    for (const [idx, msgs] of schemaErrors) {
-      const existing = structural.get(idx)
-      if (existing) existing.unshift(...msgs)
-      else structural.set(idx, msgs)
+    for (const [idx, entryIssues] of schemaIssues) {
+      const existing = structural.get(idx) ?? []
+      structural.set(idx, [...entryIssues, ...existing])
     }
 
-    opts.rowErrors.value = structural
-    if (structural.size > 0) {
-      log.warn('Validation errors found', { errorCount: structural.size, totalRows: total })
+    opts.rowErrors.value = new Map(
+      Array.from(structural.entries()).map(([idx, rowIssues]) => [idx, rowIssues.map(formatIssueMessage)]),
+    )
+    if (opts.rowErrors.value.size > 0) {
+      log.warn('Validation errors found', { errorCount: opts.rowErrors.value.size, totalRows: total })
     }
 
     opts.progress.idle()
   }
 
   function revalidateStructural() {
-    // Remove stale structural errors, preserve schema errors
+    // Preserve pre-existing non-structural messages, refresh structural messages
     const cleaned = new Map<number, string[]>()
     opts.rowErrors.value.forEach((msgs, idx) => {
-      const schemaOnly = msgs.filter(m => !isStructuralError(m))
-      if (schemaOnly.length > 0) cleaned.set(idx, schemaOnly)
+      const nonStructural = msgs.filter(msg => !isStructuralMessage(msg))
+      if (nonStructural.length > 0) cleaned.set(idx, nonStructural)
     })
 
-    // Add fresh structural errors across all rows
-    const structural = computeStructuralErrors(opts.entries.value)
-    structural.forEach((msgs, idx) => {
+    const structural = computeStructuralIssues(opts.entries.value)
+    structural.forEach((entryIssues, idx) => {
       const existing = cleaned.get(idx) ?? []
-      cleaned.set(idx, [...existing, ...msgs])
+      cleaned.set(idx, [...existing, ...entryIssues.map(formatIssueMessage)])
     })
 
     opts.rowErrors.value = cleaned
@@ -82,11 +95,11 @@ export function _useReview(opts: ReviewPhaseOptions): ReviewPhase & { _reset: ()
     ;(entry as Record<string, unknown>)[field] = value
 
     // Update schema errors for the edited row (structural refreshed below)
-    const result = SeniorityEntrySchema.safeParse(entry)
-    if (result.success) {
+    const issues = formatSchemaIssues(entry)
+    if (issues.length === 0) {
       opts.rowErrors.value.delete(rowIndex)
     } else {
-      opts.rowErrors.value.set(rowIndex, result.error.issues.map(issue => `${issue.path.join('.')}: ${issue.message}`))
+      opts.rowErrors.value.set(rowIndex, issues.map(formatIssueMessage))
     }
 
     revalidateStructural()
@@ -185,6 +198,19 @@ export function _useReview(opts: ReviewPhaseOptions): ReviewPhase & { _reset: ()
     opts.rowErrors.value = new Map()
   }
 
+  function toValidatedEntries(): SeniorityEntry[] {
+    if (opts.rowErrors.value.size > 0) {
+      throw new Error('Cannot convert to validated entries while row errors exist')
+    }
+    return opts.entries.value.map((entry, idx) => {
+      const parsed = SeniorityEntrySchema.safeParse(entry)
+      if (!parsed.success) {
+        throw new Error(`Row ${idx + 1} is not schema-valid`)
+      }
+      return parsed.data
+    })
+  }
+
   return {
     entries: opts.entries,
     rowErrors: opts.rowErrors,
@@ -196,6 +222,7 @@ export function _useReview(opts: ReviewPhaseOptions): ReviewPhase & { _reset: ()
     deleteRow,
     deleteErrorRows,
     insertRowAt,
+    toValidatedEntries,
     validate,
     _reset: reset,
   }

--- a/app/composables/seniority/upload/defaults.ts
+++ b/app/composables/seniority/upload/defaults.ts
@@ -1,0 +1,17 @@
+import type { ColumnMap, MappingOptions } from '~/utils/parse-spreadsheet'
+
+export const DEFAULT_COLUMN_MAP: ColumnMap = {
+  seniority_number: -1,
+  employee_number: -1,
+  seat: -1,
+  base: -1,
+  fleet: -1,
+  name: -1,
+  hire_date: -1,
+  retire_date: -1,
+}
+
+export const DEFAULT_MAPPING_OPTIONS: MappingOptions = {
+  nameMode: 'single',
+  retireMode: 'direct',
+}

--- a/app/composables/seniority/upload/index.test.ts
+++ b/app/composables/seniority/upload/index.test.ts
@@ -127,7 +127,7 @@ describe('useSeniorityUpload (orchestrator)', () => {
         makeDomainEntry({ seniority_number: 1, employee_number: 'E001', seat: 'CA', base: 'LAX', fleet: 'B737', hire_date: '2010-01-01', retire_date: '2040-01-01' }),
       ]
 
-      const count = await upload.confirm.save(upload.review.entries.value)
+      const count = await upload.confirm.save(upload.review.toValidatedEntries())
 
       expect(count).toBe(1)
       expect(mockStore.addList).toHaveBeenCalledTimes(1)

--- a/app/composables/seniority/upload/index.ts
+++ b/app/composables/seniority/upload/index.ts
@@ -8,19 +8,9 @@ import { _useFileIO } from './_useFileIO'
 import { _useColumnMapping } from './_useColumnMapping'
 import { _useReview } from './_useReview'
 import { _useConfirm } from './_useConfirm'
+import { DEFAULT_COLUMN_MAP } from './defaults'
 
 export type { SeniorityUpload, ProcessingPhase, ProgressTracker } from './types'
-
-const DEFAULT_COLUMN_MAP: ColumnMap = {
-  seniority_number: -1,
-  employee_number: -1,
-  seat: -1,
-  base: -1,
-  fleet: -1,
-  name: -1,
-  hire_date: -1,
-  retire_date: -1,
-}
 
 export function useSeniorityUpload(): SeniorityUpload {
   // ── Shared refs (owned here, passed to phases) ──────────────────────────

--- a/app/composables/seniority/upload/types.ts
+++ b/app/composables/seniority/upload/types.ts
@@ -83,6 +83,7 @@ export interface ReviewPhase {
   deleteRow(rowIndex: number): void
   deleteErrorRows(): number
   insertRowAt(rowIndex: number): void
+  toValidatedEntries(): SeniorityEntry[]
   validate(): Promise<void>
 }
 
@@ -102,7 +103,7 @@ export interface ConfirmPhase {
   saving: Readonly<Ref<boolean>>
   error: Readonly<Ref<string | null>>
 
-  save(entries: Partial<SeniorityEntry>[]): Promise<number>
+  save(entries: SeniorityEntry[]): Promise<number>
 }
 
 export interface ConfirmPhaseOptions {

--- a/app/pages/seniority/upload.test.ts
+++ b/app/pages/seniority/upload.test.ts
@@ -63,6 +63,7 @@ mockNuxtImport('useSeniorityUpload', () => () => ({
     deleteRow: vi.fn(),
     deleteErrorRows: vi.fn().mockReturnValue(0),
     insertRowAt: mockInsertRowAt,
+    toValidatedEntries: vi.fn().mockReturnValue([]),
   },
   confirm: {
     effectiveDate: { value: null },

--- a/app/pages/seniority/upload.vue
+++ b/app/pages/seniority/upload.vue
@@ -116,7 +116,7 @@ function onDeleteErrorRows() {
 
 async function onSave() {
   try {
-    const count = await upload.confirm.save(upload.review.entries.value)
+    const count = await upload.confirm.save(upload.review.toValidatedEntries())
     toast.add({ title: `Uploaded ${count} entries`, color: 'success' })
     upload.reset()
     await navigateTo({ path: '/dashboard', query: { tab: 'seniority' } })

--- a/app/utils/seniority-engine/snapshot.ts
+++ b/app/utils/seniority-engine/snapshot.ts
@@ -2,14 +2,17 @@ import type { SeniorityEntry } from '~/utils/schemas/seniority-list'
 import type { SenioritySnapshot, Qual } from './types'
 import { cellKey } from './cell-key'
 
-/**
- * Returns all cross-row snapshot invariant violations as a row-indexed error map.
- * Checks the same constraints that createSnapshot enforces (uniqueness of seniority
- * and employee numbers) but collects every violation instead of failing on the first.
- * Used by computeStructuralErrors as the authoritative source for these rules.
- */
-export function validateSnapshotEntries(entries: Partial<SeniorityEntry>[]): Map<number, string[]> {
-  const errors = new Map<number, string[]>()
+export type SnapshotIssueCode = 'duplicate_seniority_number' | 'duplicate_employee_number'
+
+export interface SnapshotValidationIssue {
+  code: SnapshotIssueCode
+  field: 'seniority_number' | 'employee_number'
+  rowIndex: number
+  message: string
+}
+
+function collectDuplicateIssues(entries: readonly Partial<SeniorityEntry>[]): SnapshotValidationIssue[] {
+  const issues: SnapshotValidationIssue[] = []
 
   const senNumToIndices = new Map<number, number[]>()
   entries.forEach((entry, i) => {
@@ -22,10 +25,13 @@ export function validateSnapshotEntries(entries: Partial<SeniorityEntry>[]): Map
   })
   for (const [num, indices] of senNumToIndices) {
     if (indices.length > 1) {
-      for (const i of indices) {
-        const errs = errors.get(i) ?? []
-        errs.push(`seniority_number: Duplicate seniority number ${num}`)
-        errors.set(i, errs)
+      for (const rowIndex of indices) {
+        issues.push({
+          code: 'duplicate_seniority_number',
+          field: 'seniority_number',
+          rowIndex,
+          message: `Duplicate seniority number ${num}`,
+        })
       }
     }
   }
@@ -41,15 +47,42 @@ export function validateSnapshotEntries(entries: Partial<SeniorityEntry>[]): Map
   })
   for (const [emp, indices] of empToIndices) {
     if (indices.length > 1) {
-      for (const i of indices) {
-        const errs = errors.get(i) ?? []
-        errs.push(`employee_number: Duplicate employee number ${emp}`)
-        errors.set(i, errs)
+      for (const rowIndex of indices) {
+        issues.push({
+          code: 'duplicate_employee_number',
+          field: 'employee_number',
+          rowIndex,
+          message: `Duplicate employee number ${emp}`,
+        })
       }
     }
   }
 
+  return issues
+}
+
+function issuesToErrorMap(issues: SnapshotValidationIssue[]): Map<number, string[]> {
+  const errors = new Map<number, string[]>()
+  for (const issue of issues) {
+    const rowErrors = errors.get(issue.rowIndex) ?? []
+    rowErrors.push(`${issue.field}: ${issue.message}`)
+    errors.set(issue.rowIndex, rowErrors)
+  }
   return errors
+}
+
+/**
+ * Returns all cross-row snapshot invariant violations as a row-indexed error map.
+ * Checks the same constraints that createSnapshot enforces (uniqueness of seniority
+ * and employee numbers) but collects every violation instead of failing on the first.
+ * Used by computeStructuralErrors as the authoritative source for these rules.
+ */
+export function validateSnapshotEntries(entries: Partial<SeniorityEntry>[]): Map<number, string[]> {
+  return issuesToErrorMap(collectDuplicateIssues(entries))
+}
+
+export function validateSnapshotEntryIssues(entries: readonly Partial<SeniorityEntry>[]): SnapshotValidationIssue[] {
+  return collectDuplicateIssues(entries)
 }
 
 export function uniqueEntryValues(entries: SeniorityEntry[], field: 'fleet' | 'seat' | 'base'): string[] {
@@ -68,17 +101,15 @@ export class InvalidSnapshotDataError extends Error {
 }
 
 export function createSnapshot(entries: readonly SeniorityEntry[]): SenioritySnapshot {
-  const seenSenNums = new Set<number>()
-  const seenEmpNums = new Set<string>()
+  const duplicateIssues = validateSnapshotEntryIssues(entries)
+  if (duplicateIssues.length > 0) {
+    const issue = duplicateIssues[0]!
+    throw new InvalidSnapshotDataError(`${issue.message}.`, entries[issue.rowIndex])
+  }
+
   for (const e of entries) {
     if (!e.base || !e.seat || !e.fleet)
       throw new InvalidSnapshotDataError(`Entry is missing required qual data (base/seat/fleet).`, e)
-    if (seenSenNums.has(e.seniority_number))
-      throw new InvalidSnapshotDataError(`Duplicate seniority number: ${e.seniority_number}.`, e)
-    if (seenEmpNums.has(e.employee_number))
-      throw new InvalidSnapshotDataError(`Duplicate employee number: ${e.employee_number}.`, e)
-    seenSenNums.add(e.seniority_number)
-    seenEmpNums.add(e.employee_number)
   }
 
   const sortedEntries = entries

--- a/app/utils/validate-entries.ts
+++ b/app/utils/validate-entries.ts
@@ -1,14 +1,49 @@
 import type { SeniorityEntry } from '~/utils/schemas/seniority-list'
 import { SeniorityEntrySchema } from '~/utils/schemas/seniority-list'
-import { validateSnapshotEntries } from '~/utils/seniority-engine/snapshot'
+import { validateSnapshotEntryIssues } from '~/utils/seniority-engine/snapshot'
+
+export type ValidationIssueCode
+  = | 'duplicate_seniority_number'
+    | 'duplicate_employee_number'
+    | 'non_contiguous_seniority_number'
+    | 'schema_violation'
+
+export interface ValidationIssue {
+  code: ValidationIssueCode
+  field: string
+  rowIndex: number
+  message: string
+}
+
+function pushIssue(map: Map<number, ValidationIssue[]>, issue: ValidationIssue) {
+  const rowIssues = map.get(issue.rowIndex) ?? []
+  rowIssues.push(issue)
+  map.set(issue.rowIndex, rowIssues)
+}
+
+function issuesToErrorMap(issues: Map<number, ValidationIssue[]>): Map<number, string[]> {
+  const errors = new Map<number, string[]>()
+  for (const [rowIndex, rowIssues] of issues) {
+    errors.set(rowIndex, rowIssues.map(issue => `${issue.field}: ${issue.message}`))
+  }
+  return errors
+}
 
 /**
  * Structural validation: snapshot invariants (duplicate seniority/employee numbers)
  * plus the upload-specific contiguity requirement (1..N sequence).
  * Does not run Zod schema validation. Pure function — no side effects.
  */
-export function computeStructuralErrors(entries: Partial<SeniorityEntry>[]): Map<number, string[]> {
-  const errors = validateSnapshotEntries(entries)
+export function computeStructuralIssues(entries: Partial<SeniorityEntry>[]): Map<number, ValidationIssue[]> {
+  const issues = new Map<number, ValidationIssue[]>()
+  for (const snapshotIssue of validateSnapshotEntryIssues(entries)) {
+    pushIssue(issues, {
+      code: snapshotIssue.code,
+      field: snapshotIssue.field,
+      rowIndex: snapshotIssue.rowIndex,
+      message: snapshotIssue.message,
+    })
+  }
 
   // Contiguity is an upload requirement; the snapshot engine does not enforce it
   const senNumToIndices = new Map<number, number[]>()
@@ -29,17 +64,24 @@ export function computeStructuralErrors(entries: Partial<SeniorityEntry>[]): Map
       const expectedSet = new Set(Array.from({ length: expected }, (_, i) => i + 1))
       for (const [num, indices] of senNumToIndices) {
         if (!expectedSet.has(num)) {
-          for (const i of indices) {
-            const existing = errors.get(i) ?? []
-            existing.push(`seniority_number: Non-contiguous sequence — expected 1..${expected}, found ${num}`)
-            errors.set(i, existing)
+          for (const rowIndex of indices) {
+            pushIssue(issues, {
+              code: 'non_contiguous_seniority_number',
+              field: 'seniority_number',
+              rowIndex,
+              message: `Non-contiguous sequence — expected 1..${expected}, found ${num}`,
+            })
           }
         }
       }
     }
   }
 
-  return errors
+  return issues
+}
+
+export function computeStructuralErrors(entries: Partial<SeniorityEntry>[]): Map<number, string[]> {
+  return issuesToErrorMap(computeStructuralIssues(entries))
 }
 
 /**
@@ -47,21 +89,28 @@ export function computeStructuralErrors(entries: Partial<SeniorityEntry>[]): Map
  * Pure function — no side effects, no reactive state.
  */
 export function validateEntries(entries: Partial<SeniorityEntry>[]): Map<number, string[]> {
-  const errors = new Map<number, string[]>()
+  const issues = new Map<number, ValidationIssue[]>()
 
   entries.forEach((entry, i) => {
     const result = SeniorityEntrySchema.safeParse(entry)
     if (!result.success) {
-      errors.set(i, result.error.issues.map(issue => `${issue.path.join('.')}: ${issue.message}`))
+      for (const issue of result.error.issues) {
+        pushIssue(issues, {
+          code: 'schema_violation',
+          field: issue.path.join('.'),
+          rowIndex: i,
+          message: issue.message,
+        })
+      }
     }
   })
 
-  const structural = computeStructuralErrors(entries)
-  for (const [idx, msgs] of structural) {
-    const existing = errors.get(idx) ?? []
-    existing.push(...msgs)
-    errors.set(idx, existing)
+  const structuralIssues = computeStructuralIssues(entries)
+  for (const [idx, rowIssues] of structuralIssues) {
+    for (const issue of rowIssues) {
+      pushIssue(issues, { ...issue, rowIndex: idx })
+    }
   }
 
-  return errors
+  return issuesToErrorMap(issues)
 }


### PR DESCRIPTION
### Motivation

- Replace ad-hoc string-based structural validation with a typed issue model to make validation logic easier to compose and reason about. 
- Centralize default mapping constants into `defaults.ts` to avoid duplication. 
- Ensure the confirm/save step only receives schema-validated `SeniorityEntry` objects to prevent runtime errors when creating snapshots or persisting data.

### Description

- Extracted `DEFAULT_COLUMN_MAP` and `DEFAULT_MAPPING_OPTIONS` into `app/composables/seniority/upload/defaults.ts` and wired imports in relevant modules. 
- Reworked snapshot and validation plumbing: added typed `SnapshotValidationIssue` and `ValidationIssue` shapes, added `validateSnapshotEntryIssues`, `computeStructuralIssues`, and adapted `computeStructuralErrors`/`validateEntries` to produce both typed issues and the legacy row-string maps. 
- Updated `createSnapshot` to use the new snapshot issue detection and to throw `InvalidSnapshotDataError` with contextual entry when duplicates are present. 
- Overhauled review-phase logic to handle typed validation issues: collect schema issues, merge with structural issues, format messages for the existing UI, and introduce `toValidatedEntries()` which converts the current entries to validated `SeniorityEntry[]` or throws if errors remain. 
- Tightened the confirm-phase API to accept `SeniorityEntry[]` (fully validated) and updated callers (upload page and orchestrator test) to call `toValidatedEntries()` before saving. 
- Small supporting changes: updated types in `types.ts`, refactored helper functions for formatting and message detection, and adapted tests/mocks to the new API (`toValidatedEntries` in page mocks and updated test to call it).

### Testing

- Ran the updated unit tests for the seniority upload composables including `app/composables/seniority/upload/index.test.ts` and the upload page tests `app/pages/seniority/upload.test.ts`, and they passed. 
- Executed the full automated test suite (`vitest`) to validate integrations between `validate-entries`, `seniority-engine/snapshot`, review, and confirm flows, and it passed. 
- Verified that the upload page flow now calls `toValidatedEntries()` before calling `confirm.save`, preventing snapshot creation from receiving invalid entries.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ed5e56585c83228a405af8c5cbbf1f)