### PR TITLE
Add review row-filter state with auto-clear when errors resolved and update tests

### DIFF
--- a/app/pages/seniority/upload.test.ts
+++ b/app/pages/seniority/upload.test.ts
@@ -1,7 +1,10 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest'
 import { mountSuspended, mockNuxtImport } from '@nuxt/test-utils/runtime'
 import type { DOMWrapper } from '@vue/test-utils'
+import { ref } from 'vue'
 import UploadPage from './upload.vue'
+
+const mockReviewErrorCount = ref(0)
 
 const {
   mockSave,
@@ -55,7 +58,7 @@ mockNuxtImport('useSeniorityUpload', () => () => ({
   review: {
     entries: { value: [] },
     rowErrors: { value: new Map() },
-    errorCount: { value: 0 },
+    errorCount: mockReviewErrorCount,
     syntheticNote: { value: null },
     syntheticIndices: { value: new Set() },
     canAdvance: mockReviewCanAdvance,
@@ -143,6 +146,7 @@ describe('upload page nextStep — mapping error handling', () => {
     mockFileAutoDetected.value = true
     mockMappingCanAdvance.value = false
     mockMappingError.value = null
+    mockReviewErrorCount.value = 0
     mockApplyMapping.mockReset()
     mockApplyMapping.mockResolvedValue(undefined)
   })
@@ -158,6 +162,32 @@ describe('upload page nextStep — mapping error handling', () => {
 
     // Should be on mapping step, not review
     expect(wrapper.text()).toContain('Map Columns')
+  })
+})
+
+describe('upload page review filter behavior', () => {
+  beforeEach(() => {
+    mockFileHasData.value = true
+    mockFileAutoDetected.value = true
+    mockMappingError.value = null
+    mockReviewErrorCount.value = 1
+  })
+
+  it('auto-clears error-only view when errors are resolved', async () => {
+    const wrapper = await mountSuspended(UploadPage)
+    const nextBtn = wrapper.findAll('button').find(b => b.text().includes('Next'))
+    await nextBtn!.trigger('click')
+    await wrapper.vm.$nextTick()
+
+    const showOnlyErrorsBtn = wrapper.findAll('button').find(b => b.text().includes('Show only errors'))
+    await showOnlyErrorsBtn!.trigger('click')
+    await wrapper.vm.$nextTick()
+    expect(wrapper.text()).toContain('Viewing:')
+
+    mockReviewErrorCount.value = 0
+    await wrapper.vm.$nextTick()
+
+    expect(wrapper.text()).not.toContain('Viewing:')
   })
 })
 

--- a/app/pages/seniority/upload.vue
+++ b/app/pages/seniority/upload.vue
@@ -14,9 +14,34 @@ defineExpose({ onSave })
 const upload = useSeniorityUpload()
 const toast = useToast()
 const files = ref<File | null>(null)
-const showErrorsOnly = ref(false)
-const showEstimatedOnly = ref(false)
 const mappingSkipped = ref(false)
+const activeRowFilter = ref<'all' | 'errors' | 'estimated'>('all')
+
+const showErrorsOnly = computed(() => activeRowFilter.value === 'errors')
+const showEstimatedOnly = computed(() => activeRowFilter.value === 'estimated')
+const activeFilterLabel = computed(() => {
+  if (showErrorsOnly.value) return 'Error rows only'
+  if (showEstimatedOnly.value) return 'Estimated rows only'
+  return null
+})
+
+watch(() => upload.review.errorCount.value, (count) => {
+  if (count === 0 && showErrorsOnly.value) {
+    activeRowFilter.value = 'all'
+  }
+})
+
+function toggleErrorsOnly() {
+  activeRowFilter.value = showErrorsOnly.value ? 'all' : 'errors'
+}
+
+function toggleEstimatedOnly() {
+  activeRowFilter.value = showEstimatedOnly.value ? 'all' : 'estimated'
+}
+
+function clearRowFilter() {
+  activeRowFilter.value = 'all'
+}
 
 const stepOrder = ['upload', 'mapping', 'review', 'confirm'] as const
 type Step = typeof stepOrder[number]
@@ -62,6 +87,7 @@ function selectParser(parserId: string) {
 
 function changeFormat() {
   upload.reset()
+  clearRowFilter()
   files.value = null
   mappingSkipped.value = false
 }
@@ -119,6 +145,7 @@ async function onSave() {
     const count = await upload.confirm.save(upload.review.toValidatedEntries())
     toast.add({ title: `Uploaded ${count} entries`, color: 'success' })
     upload.reset()
+    clearRowFilter()
     await navigateTo({ path: '/dashboard', query: { tab: 'seniority' } })
   } catch {
     toast.add({ title: upload.confirm.error.value ?? 'Upload failed', color: 'error' })
@@ -270,7 +297,7 @@ async function onSave() {
                     size="sm"
                     color="info"
                     :icon="showEstimatedOnly ? 'i-lucide-filter-x' : 'i-lucide-filter'"
-                    @click="showEstimatedOnly = !showEstimatedOnly; showErrorsOnly = false"
+                    @click="toggleEstimatedOnly"
                   >
                     {{ showEstimatedOnly ? 'Show all rows' : 'Show estimated rows' }}
                   </UButton>
@@ -299,12 +326,31 @@ async function onSave() {
                     variant="ghost"
                     color="neutral"
                     :icon="showErrorsOnly ? 'i-lucide-filter-x' : 'i-lucide-filter'"
-                    @click="showErrorsOnly = !showErrorsOnly"
+                    @click="toggleErrorsOnly"
                   >
                     {{ showErrorsOnly ? 'Show all rows' : 'Show only errors' }}
                   </UButton>
                 </template>
               </UAlert>
+
+              <div
+                v-if="activeFilterLabel"
+                class="flex items-center justify-between gap-3 rounded-lg border border-(--ui-border) bg-(--ui-bg-elevated)/40 px-3 py-2"
+              >
+                <p class="text-xs text-muted">
+                  Viewing:
+                  <span class="font-medium text-(--ui-text)">{{ activeFilterLabel }}</span>
+                </p>
+                <UButton
+                  size="xs"
+                  variant="ghost"
+                  color="neutral"
+                  icon="i-lucide-rotate-ccw"
+                  @click="clearRowFilter"
+                >
+                  Reset view
+                </UButton>
+              </div>
 
               <div class="flex items-center justify-between">
                 <p class="text-sm text-muted">


### PR DESCRIPTION
### Motivation
- Replace ad-hoc boolean flags for review row filtering with a single explicit filter state to simplify toggle logic and support an active label and reset action.
- Ensure the "errors only" view is automatically cleared when validation errors are resolved to avoid a stale filtered UI state.
- Make tests reactive to the new `errorCount` ref so the component behavior can be asserted in unit tests.

### Description
- Introduce `activeRowFilter: ref<'all' | 'errors' | 'estimated'>` and derived `showErrorsOnly`, `showEstimatedOnly`, and `activeFilterLabel` computed properties to replace the previous `showErrorsOnly` and `showEstimatedOnly` booleans.
- Add `toggleErrorsOnly`, `toggleEstimatedOnly`, and `clearRowFilter` helper functions and a `watch` on `upload.review.errorCount.value` to auto-reset the active filter when the error count reaches zero.
- Wire the new filter state into the template by updating the alert action buttons to use the toggle functions, adding a visible "Viewing:" banner with a `Reset view` button, and preserving the existing props passed to `UploadReviewTable` (now using the computed flags).
- Reset the active filter when changing format (`changeFormat`) and after a successful save (`onSave`).
- Update `upload.test.ts` to use a reactive `mockReviewErrorCount` and add a new test `upload page review filter behavior` that verifies the "errors only" view auto-clears when `errorCount` becomes zero.

### Testing
- Ran the unit tests in `app/pages/seniority/upload.test.ts` via `vitest`, including the new `upload page review filter behavior` spec, and they passed.
- Existing upload flow tests such as mapping and save error handling were exercised and remain green after the changes.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ed681861d08322b7ea6f3ad66390f0)