### PR TITLE
feat(seniority): add top "Continue to Save" CTA and mobile card view for seniority list

### DIFF
--- a/app/components/seniority/SeniorityListViewer.test.ts
+++ b/app/components/seniority/SeniorityListViewer.test.ts
@@ -1,0 +1,54 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { mountSuspended, mockNuxtImport } from '@nuxt/test-utils/runtime'
+import { ref } from 'vue'
+import SeniorityListViewer from './SeniorityListViewer.vue'
+
+const mockIsMobile = ref(true)
+const mockLists = ref([{ id: 1, title: 'Latest', effectiveDate: '2026-01-01', createdAt: '2026-01-01' }])
+const mockEntries = ref([
+  {
+    seniority_number: 1,
+    employee_number: '12345',
+    name: 'Pilot One',
+    seat: 'CA',
+    base: 'ATL',
+    fleet: '737',
+    hire_date: '2010-01-01',
+    retire_date: '2030-01-01',
+    listId: 1,
+  },
+])
+
+mockNuxtImport('useSeniorityLists', () => () => ({
+  lists: mockLists,
+  entriesLoading: ref(false),
+}))
+
+mockNuxtImport('useSeniorityCore', () => () => ({
+  entries: mockEntries,
+}))
+
+mockNuxtImport('useUser', () => () => ({
+  employeeNumber: ref('12345'),
+}))
+
+vi.mock('@vueuse/core', () => ({
+  useMediaQuery: () => mockIsMobile,
+}))
+
+describe('SeniorityListViewer mobile layout', () => {
+  beforeEach(() => {
+    mockIsMobile.value = true
+  })
+
+  it('renders list rows as mobile cards with key fields', async () => {
+    const wrapper = await mountSuspended(SeniorityListViewer, {
+      props: { loading: false },
+    })
+
+    expect(wrapper.text()).toContain('Pilot One')
+    expect(wrapper.text()).toContain('Emp # 12345')
+    expect(wrapper.text()).toContain('Seat')
+    expect(wrapper.text()).toContain('Base')
+  })
+})

--- a/app/components/seniority/SeniorityListViewer.vue
+++ b/app/components/seniority/SeniorityListViewer.vue
@@ -1,45 +1,45 @@
 <script setup lang="ts">
-import { h, resolveComponent } from 'vue';
-import { useMediaQuery } from '@vueuse/core';
-import { getPaginationRowModel } from '@tanstack/vue-table';
-import type { Table, Row } from '@tanstack/vue-table';
-import type { TableColumn } from '@nuxt/ui';
-import type { SeniorityEntry } from '~/utils/schemas/seniority-list';
-import { diffYears, todayISO } from '~/utils/date';
-import { useSeniorityCore, useSeniorityLists } from '~/composables/seniority';
+import { h, resolveComponent } from 'vue'
+import { useMediaQuery } from '@vueuse/core'
+import { getPaginationRowModel } from '@tanstack/vue-table'
+import type { Table, Row } from '@tanstack/vue-table'
+import type { TableColumn } from '@nuxt/ui'
+import type { SeniorityEntry } from '~/utils/schemas/seniority-list'
+import { diffYears, todayISO } from '~/utils/date'
+import { useSeniorityCore, useSeniorityLists } from '~/composables/seniority'
 
 defineProps<{
-  loading?: boolean;
-}>();
+  loading?: boolean
+}>()
 
 // ── Types ────────────────────────────────────────────────────────────────────
-type RetirementTimeline = 'past' | 'imminent' | 'soon' | null;
-type SeniorityRow = SeniorityEntry & { _isUser: boolean; _retirementTimeline: RetirementTimeline };
+type RetirementTimeline = 'past' | 'imminent' | 'soon' | null
+type SeniorityRow = SeniorityEntry & { _isUser: boolean; _retirementTimeline: RetirementTimeline }
 
 // ── Data ─────────────────────────────────────────────────────────────────────
-const { lists, entriesLoading } = useSeniorityLists();
-const { entries } = useSeniorityCore();
-const { employeeNumber } = useUser();
-const userEmployeeNumber = computed(() => employeeNumber.value ?? null);
-const latestList = computed(() => lists.value[0] ?? null);
+const { lists, entriesLoading } = useSeniorityLists()
+const { entries } = useSeniorityCore()
+const { employeeNumber } = useUser()
+const userEmployeeNumber = computed(() => employeeNumber.value ?? null)
+const latestList = computed(() => lists.value[0] ?? null)
 
 // ── Retirement timeline ───────────────────────────────────────────────────────
-const timelineClasses = new Map<RetirementTimeline, { row: string; cell: string; expanded: string }>([
+const timelineClasses = new Map<RetirementTimeline, { row: string, cell: string, expanded: string }>([
   ['past',     { row: 'bg-past/10',     cell: 'text-past/50',     expanded: 'text-past/70'     }],
   ['imminent', { row: 'bg-imminent/10', cell: 'text-imminent/50', expanded: 'text-imminent/70' }],
   ['soon',     { row: 'bg-soon/10',     cell: 'text-soon',        expanded: 'text-soon'        }],
-]);
+])
 
 function retirementTimeline(today: string, retireDate: string): RetirementTimeline {
-  const days = diffYears(today, retireDate) * 365.25;
-  if (days < 0) return 'past';
-  if (days <= 180) return 'imminent';
-  if (days <= 365) return 'soon';
-  return null;
+  const days = diffYears(today, retireDate) * 365.25
+  if (days < 0) return 'past'
+  if (days <= 180) return 'imminent'
+  if (days <= 365) return 'soon'
+  return null
 }
 
 // ── Table config ──────────────────────────────────────────────────────────────
-const isMobile = useMediaQuery('(max-width: 639px)');
+const isMobile = useMediaQuery('(max-width: 639px)')
 
 const columnVisibility = computed(() => ({
   expand: isMobile.value,
@@ -77,7 +77,7 @@ const columns: TableColumn<SeniorityRow>[] = [
     header: 'Retire Date',
     cell: ({ row }) => h('span', { class: timelineClasses.get(row.original._retirementTimeline)?.cell }, row.original.retire_date ?? ''),
   },
-];
+]
 
 const tableMeta = {
   class: {
@@ -86,39 +86,80 @@ const tableMeta = {
       timelineClasses.get(row.original._retirementTimeline)?.row ?? '',
     ].join(' ').trim(),
   },
-};
+}
 
 // ── Table state ───────────────────────────────────────────────────────────────
-const table = useTemplateRef<{ tableApi: Table<SeniorityRow> }>('table');
-const globalFilter = ref('');
-const expanded = ref({});
-const pagination = ref({ pageIndex: 0, pageSize: 50 });
+const table = useTemplateRef<{ tableApi: Table<SeniorityRow> }>('table')
+const globalFilter = ref('')
+const expanded = ref({})
+const pagination = ref({ pageIndex: 0, pageSize: 50 })
 
-const currentPage = computed(() => (table.value?.tableApi?.getState().pagination.pageIndex ?? 0) + 1);
-const pageCount = computed(() => table.value?.tableApi?.getPageCount() ?? 1);
-const totalRows = computed(() => table.value?.tableApi?.getFilteredRowModel().rows.length ?? 0);
+const mobileFilteredData = computed(() => {
+  const term = globalFilter.value.trim().toLowerCase()
+  if (!term) return tableData.value
+
+  return tableData.value.filter(row => [
+    row.name,
+    row.employee_number,
+    String(row.seniority_number),
+    row.base,
+    row.fleet,
+    row.seat,
+  ].some(value => (value ?? '').toString().toLowerCase().includes(term)))
+})
+
+const mobilePageRows = computed(() => {
+  if (!isMobile.value) return []
+  const start = pagination.value.pageIndex * pagination.value.pageSize
+  return mobileFilteredData.value.slice(start, start + pagination.value.pageSize)
+})
+
+const currentPage = computed(() => {
+  if (isMobile.value) return pagination.value.pageIndex + 1
+  return (table.value?.tableApi?.getState().pagination.pageIndex ?? 0) + 1
+})
+
+const pageCount = computed(() => {
+  if (isMobile.value) return Math.max(1, Math.ceil(mobileFilteredData.value.length / pagination.value.pageSize))
+  return table.value?.tableApi?.getPageCount() ?? 1
+})
+
+const totalRows = computed(() => {
+  if (isMobile.value) return mobileFilteredData.value.length
+  return table.value?.tableApi?.getFilteredRowModel().rows.length ?? 0
+})
 
 // Imperatively sync filter to TanStack — v-model:global-filter alone doesn't
 // trigger recomputation because TanStack's mergeProxy lazily evaluates state getters.
 watch(globalFilter, (value) => {
+  pagination.value.pageIndex = 0
   if (table.value?.tableApi) {
-    table.value.tableApi.setGlobalFilter(value);
-    table.value.tableApi.setPageIndex(0);
+    table.value.tableApi.setGlobalFilter(value)
+    table.value.tableApi.setPageIndex(0)
   }
-  else {
-    pagination.value.pageIndex = 0;
-  }
-});
+})
 
 // ── Derived data ──────────────────────────────────────────────────────────────
 const tableData = computed<SeniorityRow[]>(() => {
-  const today = todayISO();
+  const today = todayISO()
   return entries.value.map(entry => ({
     ...entry,
     _isUser: !!userEmployeeNumber.value && entry.employee_number === userEmployeeNumber.value,
     _retirementTimeline: entry.retire_date ? retirementTimeline(today, entry.retire_date) : null,
-  }));
-});
+  }))
+})
+
+const mobileTimelineTone = computed<Record<Exclude<RetirementTimeline, null>, 'error' | 'warning' | 'secondary'>>(() => ({
+  past: 'secondary',
+  imminent: 'error',
+  soon: 'warning',
+}))
+
+function updatePage(page: number) {
+  const pageIndex = Math.max(0, page - 1)
+  pagination.value.pageIndex = pageIndex
+  table.value?.tableApi?.setPageIndex(pageIndex)
+}
 </script>
 
 <template>
@@ -141,7 +182,57 @@ const tableData = computed<SeniorityRow[]>(() => {
         <!-- List viewer -->
         <template v-else>
 
-          <div class="overflow-x-auto">
+          <div v-if="isMobile" class="space-y-3 px-2 py-3">
+            <UCard
+              v-for="row in mobilePageRows"
+              :key="`${row.employee_number}-${row.seniority_number}`"
+              :ui="{ body: 'p-3' }"
+              :class="row._isUser ? 'ring-1 ring-primary/60' : ''"
+            >
+              <div class="space-y-2">
+                <div class="flex items-start justify-between gap-3">
+                  <div>
+                    <p class="font-semibold leading-tight">{{ row.name || 'Unknown name' }}</p>
+                    <p class="text-xs text-muted">Emp # {{ row.employee_number || '—' }}</p>
+                  </div>
+                  <UBadge color="neutral" variant="subtle">#{{ row.seniority_number }}</UBadge>
+                </div>
+
+                <div class="grid grid-cols-2 gap-x-4 gap-y-2 text-xs">
+                  <div>
+                    <p class="text-muted">Seat</p>
+                    <p>{{ row.seat || '—' }}</p>
+                  </div>
+                  <div>
+                    <p class="text-muted">Base</p>
+                    <p>{{ row.base || '—' }}</p>
+                  </div>
+                  <div>
+                    <p class="text-muted">Fleet</p>
+                    <p>{{ row.fleet || '—' }}</p>
+                  </div>
+                  <div>
+                    <p class="text-muted">Hire Date</p>
+                    <p>{{ row.hire_date || '—' }}</p>
+                  </div>
+                </div>
+
+                <div class="flex items-center justify-between">
+                  <p class="text-xs text-muted">Retire Date</p>
+                  <UBadge
+                    v-if="row.retire_date"
+                    :color="row._retirementTimeline ? mobileTimelineTone[row._retirementTimeline] : 'neutral'"
+                    variant="soft"
+                  >
+                    {{ row.retire_date }}
+                  </UBadge>
+                  <span v-else class="text-xs">—</span>
+                </div>
+              </div>
+            </UCard>
+          </div>
+
+          <div v-else class="overflow-x-auto">
             <UTable ref="table" v-model:global-filter="globalFilter" v-model:pagination="pagination"
               v-model:expanded="expanded" v-model:column-visibility="columnVisibility" :data="tableData"
               :columns="columns" :loading="loading || entriesLoading"
@@ -183,7 +274,7 @@ const tableData = computed<SeniorityRow[]>(() => {
     <!-- Pagination — floats below scroll area, always visible -->
     <div v-if="latestList" class="shrink-0 py-2 sm:py-3 border-t border-default">
       <TablePagination :current-page="currentPage" :page-count="pageCount" :total-rows="totalRows"
-        :page-size="pagination.pageSize" @update:page="(p: number) => table?.tableApi?.setPageIndex(p - 1)" />
+        :page-size="pagination.pageSize" @update:page="updatePage" />
     </div>
   </div>
 </template>

--- a/app/pages/seniority/upload.test.ts
+++ b/app/pages/seniority/upload.test.ts
@@ -189,6 +189,23 @@ describe('upload page review filter behavior', () => {
 
     expect(wrapper.text()).not.toContain('Viewing:')
   })
+
+  it('shows a top review action button to continue without scrolling', async () => {
+    mockReviewCanAdvance.value = true
+
+    const wrapper = await mountSuspended(UploadPage)
+    const nextBtn = wrapper.findAll('button').find(b => b.text().includes('Next'))
+    await nextBtn!.trigger('click')
+    await wrapper.vm.$nextTick()
+
+    const topContinueButton = wrapper.findAll('button').find(b => b.text().includes('Continue to Save'))
+    expect(topContinueButton).toBeDefined()
+
+    await topContinueButton!.trigger('click')
+    await wrapper.vm.$nextTick()
+
+    expect(wrapper.text()).toContain('Effective Date')
+  })
 })
 
 describe('upload page canAdvance — mapping step', () => {

--- a/app/pages/seniority/upload.vue
+++ b/app/pages/seniority/upload.vue
@@ -284,6 +284,20 @@ async function onSave() {
 
             <!-- Step 3: Review & Validate -->
             <div v-else-if="currentStep === 'review'" class="space-y-4">
+              <div class="sticky top-0 z-10 -mx-2 sm:mx-0 px-2 sm:px-0 py-2 bg-(--ui-bg)/95 backdrop-blur supports-[backdrop-filter]:bg-(--ui-bg)/80">
+                <div class="flex justify-end">
+                  <UButton
+                    :disabled="!canAdvance || upload.progress.busy.value"
+                    :loading="upload.progress.busy.value"
+                    icon="i-lucide-arrow-right"
+                    trailing
+                    @click="nextStep"
+                  >
+                    Continue to Save
+                  </UButton>
+                </div>
+              </div>
+
               <UAlert
                 v-if="upload.review.syntheticNote.value"
                 icon="i-lucide-info"


### PR DESCRIPTION
### Motivation

- Users must currently scroll to the bottom of the review step to continue the upload flow, which is inconvenient when many rows or errors are present, so a top action is needed to proceed without scrolling.
- The `SeniorityListViewer` relied on a horizontally-scrollable table on mobile, which makes data hard to scan; a compact, readable mobile layout is required using Nuxt UI primitives.

### Description

- Added a sticky top action in the upload review step: a Nuxt UI `UButton` labeled `Continue to Save` that mirrors the existing `canAdvance` / busy gating and triggers `nextStep`, placed at the top of the review UI so users can proceed without scrolling. (`app/pages/seniority/upload.vue`)
- Reworked `SeniorityListViewer` to detect mobile via `useMediaQuery` and render a card-based mobile layout using `UCard`, `UBadge`, and Nuxt UI tokens that surface key fields (name, emp #, seat, base, fleet, hire/retire dates) for easier reading. Desktop keeps the existing `UTable`. (`app/components/seniority/SeniorityListViewer.vue`)
- Preserved search and pagination behavior across both layouts by adding mobile filtering and pagination helpers (`mobileFilteredData`, `mobilePageRows`, `updatePage`) and routing pagination updates through a shared `updatePage` handler. (`app/components/seniority/SeniorityListViewer.vue`)
- Added tests and small test updates: new mobile layout test for `SeniorityListViewer` and an upload test asserting the new top review CTA appears and advances to the confirm step. (`app/components/seniority/SeniorityListViewer.test.ts`, `app/pages/seniority/upload.test.ts`)

### Testing

- Ran `pnpm lint` and it completed without errors.
- Ran `pnpm typecheck` (`vue-tsc --noEmit`) and it completed without errors.
- Ran `pnpm test` and all tests passed (test suite completed successfully).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ed79adcf6c8322a102d92fb1da72cf)