### PR TITLE
fix(seniority): order dashboard/compare recency by effectiveDate

### DIFF
--- a/app/pages/seniority/compare.test.ts
+++ b/app/pages/seniority/compare.test.ts
@@ -80,6 +80,27 @@ describe('seniority/compare.vue — route-synced ref / watcher race condition', 
     mockNavigateTo.mockResolvedValue(undefined)
   })
 
+
+  it('auto-selects older/newer by effectiveDate when query params are missing', async () => {
+    const olderByEffective = makeList(11, '2026-01-01')
+    const newestByUploadButOlderEffective = { ...makeList(22, '2025-12-01'), createdAt: '2026-04-01T00:00:00Z' }
+    const newerByEffective = { ...makeList(33, '2026-03-01'), createdAt: '2026-01-01T00:00:00Z' }
+
+    mockRouteQuery.value = {}
+    mockFetchLists.mockImplementation(() => {
+      // Store/composable contract provides lists in recency order.
+      // Simulate effectiveDate ordering explicitly here.
+      mockLists.value = [newerByEffective, olderByEffective, newestByUploadButOlderEffective]
+    })
+
+    const ComparePage = await import('./compare.vue')
+    const wrapper = await mountSuspended(ComparePage.default)
+    const vm = wrapper.vm as unknown as { listIdA: number | undefined; listIdB: number | undefined }
+
+    expect(vm.listIdA).toBe(11)
+    expect(vm.listIdB).toBe(33)
+  })
+
   it('does NOT call navigateTo during mount when URL already has ?a=A&b=B', async () => {
     const A_ID = 1
     const B_ID = 2

--- a/app/stores/seniority.test.ts
+++ b/app/stores/seniority.test.ts
@@ -39,7 +39,7 @@ vi.mock('~/utils/db', () => ({ db: mockDb }))
 const mockList1: LocalSeniorityList = {
   id: 1,
   title: 'January List',
-  effectiveDate: '2026-01-15',
+  effectiveDate: '2026-03-15',
   createdAt: '2026-01-10T12:00:00Z',
 }
 
@@ -95,7 +95,7 @@ describe('seniority store (Dexie)', () => {
   })
 
   describe('fetchLists', () => {
-    it('queries Dexie and sorts lists by upload recency (createdAt) descending', async () => {
+    it('queries Dexie and sorts lists by effectiveDate descending before upload recency', async () => {
       mockDb.seniorityLists.toArray.mockResolvedValue([mockList1, mockList2])
 
       const { useSeniorityStore } = await import('./seniority')
@@ -105,16 +105,16 @@ describe('seniority store (Dexie)', () => {
       await store.fetchLists()
 
       expect(store.lists).toHaveLength(2)
-      // mockList2 has the later createdAt (2026-02-10) so it sorts first
-      expect(store.lists[0]!.id).toBe(2)
-      expect(store.lists[1]!.id).toBe(1)
+      // mockList1 has the newer effectiveDate (2026-03-15) so it sorts first
+      expect(store.lists[0]!.id).toBe(1)
+      expect(store.lists[1]!.id).toBe(2)
     })
 
-    it('breaks createdAt ties by effectiveDate, then by id descending', async () => {
-      const sameCreated1: LocalSeniorityList = { id: 3, title: null, effectiveDate: '2026-03-01', createdAt: '2026-03-01T10:00:00Z' }
-      const sameCreated2: LocalSeniorityList = { id: 7, title: null, effectiveDate: '2026-03-01', createdAt: '2026-03-01T10:00:00Z' }
-      const sameCreatedNewerEffective: LocalSeniorityList = { id: 4, title: null, effectiveDate: '2026-04-01', createdAt: '2026-03-01T10:00:00Z' }
-      mockDb.seniorityLists.toArray.mockResolvedValue([sameCreated1, sameCreated2, sameCreatedNewerEffective])
+    it('breaks effectiveDate ties by createdAt, then by id descending', async () => {
+      const sameEffectiveOlderUpload: LocalSeniorityList = { id: 3, title: null, effectiveDate: '2026-03-01', createdAt: '2026-03-01T09:00:00Z' }
+      const sameEffectiveNewerUploadLowerId: LocalSeniorityList = { id: 4, title: null, effectiveDate: '2026-03-01', createdAt: '2026-03-01T10:00:00Z' }
+      const sameEffectiveNewerUploadHigherId: LocalSeniorityList = { id: 7, title: null, effectiveDate: '2026-03-01', createdAt: '2026-03-01T10:00:00Z' }
+      mockDb.seniorityLists.toArray.mockResolvedValue([sameEffectiveOlderUpload, sameEffectiveNewerUploadLowerId, sameEffectiveNewerUploadHigherId])
 
       const { useSeniorityStore } = await import('./seniority')
       const store = useSeniorityStore()
@@ -122,9 +122,9 @@ describe('seniority store (Dexie)', () => {
 
       await store.fetchLists()
 
-      // same createdAt: newer effectiveDate wins, then higher id
-      expect(store.lists[0]!.id).toBe(4)
-      expect(store.lists[1]!.id).toBe(7)
+      // same effectiveDate: newer upload wins, then higher id
+      expect(store.lists[0]!.id).toBe(7)
+      expect(store.lists[1]!.id).toBe(4)
       expect(store.lists[2]!.id).toBe(3)
     })
 

--- a/app/stores/seniority.ts
+++ b/app/stores/seniority.ts
@@ -9,10 +9,12 @@ import { emitHook } from '~/utils/hooks'
 const log = createLogger('seniority-store')
 
 function compareListsByRecency(a: LocalSeniorityList, b: LocalSeniorityList): number {
-  const createdCmp = (b.createdAt ?? '').localeCompare(a.createdAt ?? '')
-  if (createdCmp !== 0) return createdCmp
   const effectiveCmp = b.effectiveDate.localeCompare(a.effectiveDate)
   if (effectiveCmp !== 0) return effectiveCmp
+
+  const createdCmp = (b.createdAt ?? '').localeCompare(a.createdAt ?? '')
+  if (createdCmp !== 0) return createdCmp
+
   return (b.id ?? 0) - (a.id ?? 0)
 }
 


### PR DESCRIPTION
### Motivation
- The dashboard and compare UI marked a newly uploaded list as historical when a different list had a later `effectiveDate`, because sorting used upload timestamp instead of effective date.
- The app needs to consider `effectiveDate` as the primary recency metric so "most recent"/"historical" and the compare auto-selection reflect business intent.

### Description
- Changed `compareListsByRecency` in `app/stores/seniority.ts` to sort by `effectiveDate` (descending) first, then `createdAt`, then `id` for deterministic tie-breaking.
- Updated store tests in `app/stores/seniority.test.ts` to assert effective-date-first ordering and to verify tie-break behavior (createdAt then id).
- Added a compare page test in `app/pages/seniority/compare.test.ts` to ensure the auto-selection of older/newer lists follows effective-date ordering when no query params are provided.

### Testing
- Ran `pnpm lint` and it completed successfully.
- Ran `pnpm typecheck` (`vue-tsc --noEmit`) and it completed successfully.
- Ran unit tests with `pnpm test` and all tests passed (full test run: 78 files, 785 tests; modified-spec runs also passed).
- Also executed `pnpm test app/stores/seniority.test.ts app/pages/seniority/compare.test.ts` to validate the targeted changes and those tests passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ed87df653c832280d704cd928ffa4c)