### PR TITLE
fix(dashboard): standardize percentile labels in status views

### DIFF
--- a/app/components/analytics/PercentileThresholdCalculator.vue
+++ b/app/components/analytics/PercentileThresholdCalculator.vue
@@ -38,7 +38,7 @@ const percentileOptions = [50, 75, 90] as const
             :variant="targetPercentile === p ? 'solid' : 'outline'"
             @click="$emit('percentileChange', p)"
           >
-            Top {{ 100 - p }}%
+            {{ p }}th percentile
           </UButton>
         </UFieldGroup>
       </div>
@@ -50,8 +50,8 @@ const percentileOptions = [50, 75, 90] as const
           <p class="text-sm">
             At current attrition, you could hold
             <strong>{{ selectedQual || 'this qual' }}</strong>
-            in the
-            <strong>top {{ 100 - targetPercentile }}%</strong>
+            at the
+            <strong>{{ targetPercentile }}th percentile</strong>
             by
             <strong class="font-mono">{{ result.year }}</strong>.
           </p>

--- a/app/components/dashboard/BaseStatusTable.vue
+++ b/app/components/dashboard/BaseStatusTable.vue
@@ -69,15 +69,15 @@ const columns: TableColumn<DisplayRow>[] = [
   { accessorKey: 'fleet', header: 'Fleet', cell: ({ row }) => h('span', { class: highlightClass(row.original) }, row.original.fleet) },
   { accessorKey: 'displayRank', header: 'Rank', cell: ({ row }) => h('span', { class: highlightClass(row.original) }, row.original.displayRank) },
   { accessorKey: 'displayTotal', header: 'Total', cell: ({ row }) => h('span', { class: highlightClass(row.original) }, row.original.displayTotal) },
-  { accessorKey: 'displayPercentile', header: 'TOP %', cell: ({ row }) => h('span', { class: highlightClass(row.original) }, `${row.original.displayPercentile}%`) },
+  { accessorKey: 'displayPercentile', header: 'Base %ile', cell: ({ row }) => h('span', { class: highlightClass(row.original) }, `${row.original.displayPercentile}%`) },
 ];
 
-// 4 columns on mobile — Total dropped (Rank + TOP% convey the same standing)
+// 4 columns on mobile — Total dropped (Rank + Base %ile convey the same standing)
 const mobileColumns: TableColumn<DisplayRow>[] = [
   { accessorKey: 'base', header: 'Base', cell: ({ row }) => h('span', { class: highlightClass(row.original) }, row.original.base) },
   { accessorKey: 'fleet', header: 'Fleet', cell: ({ row }) => h('span', { class: highlightClass(row.original) }, row.original.fleet) },
   { accessorKey: 'displayRank', header: 'Rank', cell: ({ row }) => h('span', { class: `font-mono ${highlightClass(row.original)}` }, row.original.displayRank) },
-  { accessorKey: 'displayPercentile', header: 'TOP%', cell: ({ row }) => h('span', { class: `font-mono ${highlightClass(row.original)}` }, `${row.original.displayPercentile}%`) },
+  { accessorKey: 'displayPercentile', header: 'Base %ile', cell: ({ row }) => h('span', { class: `font-mono ${highlightClass(row.original)}` }, `${row.original.displayPercentile}%`) },
 ];
 </script>
 

--- a/app/components/dashboard/SeniorityRankCard.vue
+++ b/app/components/dashboard/SeniorityRankCard.vue
@@ -67,7 +67,7 @@ onMounted(() => {
 
     <div class="mt-4">
       <div class="flex justify-between text-xs text-muted mb-1">
-        <span>TOP %</span>
+        <span>Percentile</span>
         <span class="font-mono">{{ rank.percentile }}%</span>
       </div>
       <UProgress


### PR DESCRIPTION
### Motivation

- The Status by Base/Seat/Fleet table and seniority rank card used `TOP %` which is ambiguous for a percentile metric and inconsistent across the UI.  
- The percentile threshold messaging used "Top X%" phrasing which conflicts with the rest of the app's percentile-first language.  
- Standardize labels so the UI clearly communicates that the values are percentiles (and clarify base-scoped percentiles where applicable).

### Description

- Renamed the Base/Seat/Fleet table percentile column headers from `TOP %` / `TOP%` to `Base %ile` for both desktop and mobile variants in `app/components/dashboard/BaseStatusTable.vue`.  
- Changed the main seniority rank card label from `TOP %` to `Percentile` in `app/components/dashboard/SeniorityRankCard.vue`.  
- Rewrote the Percentile Threshold Calculator button and result copy to use percentile phrasing (e.g. `50th percentile`) instead of `Top X%` in `app/components/analytics/PercentileThresholdCalculator.vue`.  
- Updated an explanatory comment to reflect the new `Base %ile` wording.

### Testing

- Ran `pnpm lint` and it completed successfully.  
- Ran `pnpm typecheck` (`vue-tsc --noEmit`) and it completed successfully.  
- Ran `pnpm test` (Vitest) and the test suite passed (`Tests 785 passed`).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ee4f84d30c832286e45ac74e20f398)