### PR TITLE
Introduce remeda and migrate seniority core pipelines (snapshot + lens)

### DIFF
--- a/app/utils/seniority-engine/lens.ts
+++ b/app/utils/seniority-engine/lens.ts
@@ -30,6 +30,7 @@ import { createScenario } from './scenario'
 import { memoizeLast } from './memoize'
 import { qualSpecToFilter } from './qual-spec'
 import { computePercentile } from './percentile'
+import { pipe as rPipe, filter as rFilter, sortBy as rSortBy, map as rMap } from 'remeda'
 import {
   findThresholdYear,
   computePowerIndexCells,
@@ -229,8 +230,9 @@ export function createLens(
     const todayStr = todayISO()
     const cutoff = addYearsISO(todayStr, filter.yearsHorizon)
 
-    return entries
-      .filter((e) => {
+    return rPipe(
+      entries,
+      rFilter((e) => {
         if (!e.retire_date) return false
         if (isRetiredBy(e.retire_date, todayStr)) return false
         if (!isRetiredBy(e.retire_date, cutoff)) return false
@@ -239,9 +241,9 @@ export function createLens(
         if (filter.seat && e.seat !== filter.seat) return false
         if (filter.fleet && e.fleet !== filter.fleet) return false
         return true
-      })
-      .sort((a, b) => a.retire_date!.localeCompare(b.retire_date!))
-      .map((e): UpcomingRetirementRow => ({
+      }),
+      rSortBy((entry) => entry.retire_date!),
+      rMap((e): UpcomingRetirementRow => ({
         seniorityNumber: e.seniority_number,
         employeeNumber: e.employee_number,
         base: e.base,
@@ -251,7 +253,8 @@ export function createLens(
         rankRelativeToMe: resolvedAnchor
           ? resolvedAnchor.seniorityNumber - e.seniority_number
           : null,
-      }))
+      })),
+    )
   }
 
   return {

--- a/app/utils/seniority-engine/lens.ts
+++ b/app/utils/seniority-engine/lens.ts
@@ -31,12 +31,12 @@ import { memoizeLast } from './memoize'
 import { qualSpecToFilter } from './qual-spec'
 import { computePercentile } from './percentile'
 import {
-  pipe as rPipe,
-  filter as rFilter,
-  sortBy as rSortBy,
-  map as rMap,
-  allPass as rAllPass,
-  anyPass as rAnyPass,
+  pipe,
+  filter,
+  sortBy,
+  map,
+  allPass,
+  anyPass,
 } from 'remeda'
 import {
   findThresholdYear,
@@ -233,23 +233,23 @@ export function createLens(
     }
   }
 
-  function upcomingRetirements(filter: UpcomingRetirementFilter): UpcomingRetirementRow[] {
+  function upcomingRetirements(options: UpcomingRetirementFilter): UpcomingRetirementRow[] {
     const todayStr = todayISO()
-    const cutoff = addYearsISO(todayStr, filter.yearsHorizon)
+    const cutoff = addYearsISO(todayStr, options.yearsHorizon)
     const isSeniorToAnchor = (entry: typeof entries[number]) => (
-      !filter.seniorOnly
+      !options.seniorOnly
       || !resolvedAnchor
       || entry.seniority_number < resolvedAnchor.seniorityNumber
     )
-    const inQualScope = rAllPass([
-      (entry: typeof entries[number]) => !filter.base || entry.base === filter.base,
-      (entry: typeof entries[number]) => !filter.seat || entry.seat === filter.seat,
-      (entry: typeof entries[number]) => !filter.fleet || entry.fleet === filter.fleet,
+    const inQualScope = allPass([
+      (entry: typeof entries[number]) => !options.base || entry.base === options.base,
+      (entry: typeof entries[number]) => !options.seat || entry.seat === options.seat,
+      (entry: typeof entries[number]) => !options.fleet || entry.fleet === options.fleet,
     ])
-    const hasAnyQualFilter = rAnyPass([
-      () => !!filter.base,
-      () => !!filter.seat,
-      () => !!filter.fleet,
+    const hasAnyQualFilter = anyPass([
+      () => !!options.base,
+      () => !!options.seat,
+      () => !!options.fleet,
     ])
     const retireWithinHorizon = (entry: typeof entries[number]) => (
       !!entry.retire_date
@@ -257,15 +257,15 @@ export function createLens(
       && isRetiredBy(entry.retire_date, cutoff)
     )
 
-    return rPipe(
+    return pipe(
       entries,
-      rFilter(rAllPass([
+      filter(allPass([
         retireWithinHorizon,
         isSeniorToAnchor,
         (entry) => !hasAnyQualFilter(entry) || inQualScope(entry),
       ])),
-      rSortBy((entry) => entry.retire_date!),
-      rMap((e): UpcomingRetirementRow => ({
+      sortBy((entry) => entry.retire_date!),
+      map((e): UpcomingRetirementRow => ({
         seniorityNumber: e.seniority_number,
         employeeNumber: e.employee_number,
         base: e.base,

--- a/app/utils/seniority-engine/lens.ts
+++ b/app/utils/seniority-engine/lens.ts
@@ -30,7 +30,14 @@ import { createScenario } from './scenario'
 import { memoizeLast } from './memoize'
 import { qualSpecToFilter } from './qual-spec'
 import { computePercentile } from './percentile'
-import { pipe as rPipe, filter as rFilter, sortBy as rSortBy, map as rMap } from 'remeda'
+import {
+  pipe as rPipe,
+  filter as rFilter,
+  sortBy as rSortBy,
+  map as rMap,
+  allPass as rAllPass,
+  anyPass as rAnyPass,
+} from 'remeda'
 import {
   findThresholdYear,
   computePowerIndexCells,
@@ -229,19 +236,34 @@ export function createLens(
   function upcomingRetirements(filter: UpcomingRetirementFilter): UpcomingRetirementRow[] {
     const todayStr = todayISO()
     const cutoff = addYearsISO(todayStr, filter.yearsHorizon)
+    const isSeniorToAnchor = (entry: typeof entries[number]) => (
+      !filter.seniorOnly
+      || !resolvedAnchor
+      || entry.seniority_number < resolvedAnchor.seniorityNumber
+    )
+    const inQualScope = rAllPass([
+      (entry: typeof entries[number]) => !filter.base || entry.base === filter.base,
+      (entry: typeof entries[number]) => !filter.seat || entry.seat === filter.seat,
+      (entry: typeof entries[number]) => !filter.fleet || entry.fleet === filter.fleet,
+    ])
+    const hasAnyQualFilter = rAnyPass([
+      () => !!filter.base,
+      () => !!filter.seat,
+      () => !!filter.fleet,
+    ])
+    const retireWithinHorizon = (entry: typeof entries[number]) => (
+      !!entry.retire_date
+      && !isRetiredBy(entry.retire_date, todayStr)
+      && isRetiredBy(entry.retire_date, cutoff)
+    )
 
     return rPipe(
       entries,
-      rFilter((e) => {
-        if (!e.retire_date) return false
-        if (isRetiredBy(e.retire_date, todayStr)) return false
-        if (!isRetiredBy(e.retire_date, cutoff)) return false
-        if (filter.seniorOnly && resolvedAnchor && e.seniority_number >= resolvedAnchor.seniorityNumber) return false
-        if (filter.base && e.base !== filter.base) return false
-        if (filter.seat && e.seat !== filter.seat) return false
-        if (filter.fleet && e.fleet !== filter.fleet) return false
-        return true
-      }),
+      rFilter(rAllPass([
+        retireWithinHorizon,
+        isSeniorToAnchor,
+        (entry) => !hasAnyQualFilter(entry) || inQualScope(entry),
+      ])),
       rSortBy((entry) => entry.retire_date!),
       rMap((e): UpcomingRetirementRow => ({
         seniorityNumber: e.seniority_number,

--- a/app/utils/seniority-engine/snapshot.ts
+++ b/app/utils/seniority-engine/snapshot.ts
@@ -1,6 +1,7 @@
 import type { SeniorityEntry } from '~/utils/schemas/seniority-list'
 import type { SenioritySnapshot, Qual } from './types'
 import { cellKey } from './cell-key'
+import { pipe, map, filter, unique, sort, groupBy } from 'remeda'
 
 export type SnapshotIssueCode = 'duplicate_seniority_number' | 'duplicate_employee_number'
 
@@ -12,53 +13,47 @@ export interface SnapshotValidationIssue {
 }
 
 function collectDuplicateIssues(entries: readonly Partial<SeniorityEntry>[]): SnapshotValidationIssue[] {
-  const issues: SnapshotValidationIssue[] = []
+  const indexedEntries = entries.map((entry, rowIndex) => ({ entry, rowIndex }))
 
-  const senNumToIndices = new Map<number, number[]>()
-  entries.forEach((entry, i) => {
-    const num = entry.seniority_number
-    if (typeof num === 'number' && Number.isInteger(num) && num > 0) {
-      const indices = senNumToIndices.get(num) ?? []
-      indices.push(i)
-      senNumToIndices.set(num, indices)
-    }
-  })
-  for (const [num, indices] of senNumToIndices) {
-    if (indices.length > 1) {
-      for (const rowIndex of indices) {
-        issues.push({
-          code: 'duplicate_seniority_number',
-          field: 'seniority_number',
-          rowIndex,
-          message: `Duplicate seniority number ${num}`,
-        })
-      }
-    }
-  }
+  const seniorityNumberIssues = pipe(
+    indexedEntries,
+    filter(({ entry }) =>
+      typeof entry.seniority_number === 'number'
+      && Number.isInteger(entry.seniority_number)
+      && entry.seniority_number > 0,
+    ),
+    groupBy(({ entry }) => String(entry.seniority_number)),
+  )
+  const seniorityDuplicateGroups = Object.entries(seniorityNumberIssues).filter(([, rows]) => rows.length > 1)
+  const seniorityIssues = seniorityDuplicateGroups.flatMap(([num, rows]) =>
+    rows.map(({ rowIndex }) => ({
+      code: 'duplicate_seniority_number' as const,
+      field: 'seniority_number' as const,
+      rowIndex,
+      message: `Duplicate seniority number ${Number(num)}`,
+    })),
+  )
 
-  const empToIndices = new Map<string, number[]>()
-  entries.forEach((entry, i) => {
-    const emp = typeof entry.employee_number === 'string' ? entry.employee_number.trim() : ''
-    if (emp.length > 0) {
-      const indices = empToIndices.get(emp) ?? []
-      indices.push(i)
-      empToIndices.set(emp, indices)
-    }
-  })
-  for (const [emp, indices] of empToIndices) {
-    if (indices.length > 1) {
-      for (const rowIndex of indices) {
-        issues.push({
-          code: 'duplicate_employee_number',
-          field: 'employee_number',
-          rowIndex,
-          message: `Duplicate employee number ${emp}`,
-        })
-      }
-    }
-  }
+  const employeeNumberGroups = pipe(
+    indexedEntries,
+    map(({ entry, rowIndex }) => ({
+      employeeNumber: typeof entry.employee_number === 'string' ? entry.employee_number.trim() : '',
+      rowIndex,
+    })),
+    filter(({ employeeNumber }) => employeeNumber.length > 0),
+    groupBy(({ employeeNumber }) => employeeNumber),
+  )
+  const employeeDuplicateGroups = Object.entries(employeeNumberGroups).filter(([, rows]) => rows.length > 1)
+  const employeeIssues = employeeDuplicateGroups.flatMap(([employeeNumber, rows]) =>
+    rows.map(({ rowIndex }) => ({
+      code: 'duplicate_employee_number' as const,
+      field: 'employee_number' as const,
+      rowIndex,
+      message: `Duplicate employee number ${employeeNumber}`,
+    })),
+  )
 
-  return issues
+  return [...seniorityIssues, ...employeeIssues]
 }
 
 function issuesToErrorMap(issues: SnapshotValidationIssue[]): Map<number, string[]> {
@@ -86,12 +81,13 @@ export function validateSnapshotEntryIssues(entries: readonly Partial<SeniorityE
 }
 
 export function uniqueEntryValues(entries: SeniorityEntry[], field: 'fleet' | 'seat' | 'base'): string[] {
-  const values = new Set<string>()
-  for (const e of entries) {
-    const v = e[field]
-    if (v) values.add(v)
-  }
-  return Array.from(values).sort()
+  return pipe(
+    entries,
+    map((entry) => entry[field]),
+    filter((value): value is string => Boolean(value)),
+    unique(),
+    sort((a, b) => a.localeCompare(b)),
+  )
 }
 
 export class InvalidSnapshotDataError extends Error {

--- a/docs/remeda-seniority-core-migration.md
+++ b/docs/remeda-seniority-core-migration.md
@@ -1,0 +1,76 @@
+# Remeda migration plan for seniority core
+
+This document proposes an incremental migration path for the seniority core toward Remeda-style data pipelines.
+
+## Why this area first
+
+The seniority core already has concentrated data-shaping logic in pure utility/composable functions, which makes it a safe place to adopt `pipe()` without touching persistence or UI behavior.
+
+## Migration order (incremental)
+
+### 1) Snapshot builders and set-like extraction (low risk, high readability)
+
+**Files:** `app/utils/seniority-engine/snapshot.ts`
+
+- `uniqueEntryValues` is a straightforward transform pipeline (pluck → compact/filter → unique → sort).
+- Snapshot validation helpers (`collectDuplicateIssues`) can be migrated next by replacing imperative map-building loops with grouped pipelines while preserving error message format.
+
+**Why first:** These functions are deterministic and heavily unit-tested, so regressions are easy to catch quickly.
+
+---
+
+### 2) Lens filtering and tabular projections (medium risk, high payoff)
+
+**Files:** `app/utils/seniority-engine/lens.ts`
+
+Best candidates:
+
+- `upcomingRetirements` (filter/sort/map chain already present)
+- `standing` cell breakdown generation (iterate groups, compute metrics, reduce totals)
+- `retirementsThisYear` and derived filtered counts used by `standing`
+
+**Why second:** This is where a lot of business logic lives and where pipeline readability can reduce branching complexity, but behavior correctness is critical.
+
+---
+
+### 3) Qual analytics and heavy transforms (medium/high risk, large long-term value)
+
+**Files:** `app/utils/qual-analytics.ts`, `app/utils/seniority-math.ts`
+
+Best candidates:
+
+- Bucket and histogram generation
+- Multi-step projection transforms
+- Aggregation-heavy metrics for charts/cards
+
+**Why third:** High data volume and denser transforms mean strong wins from consistent pipeline style, but these modules have the most interconnected calculations.
+
+---
+
+### 4) Composable-level derivations only where they remain pure (targeted)
+
+**Files:** `app/composables/seniority/modules/useSeniorityCore.ts`
+
+Best candidate:
+
+- `syntheticEntry`’s max seniority number scan and option list derivations, when they stay as pure derived computations.
+
+**Why last:** Keep composables focused on orchestration/reactivity; avoid over-functionalizing watcher and persistence orchestration.
+
+## Guardrails for each migration PR
+
+1. Keep each PR scoped to one function family.
+2. Preserve public return shapes and error messages exactly.
+3. Run focused tests first, then full gates:
+   - `pnpm test app/utils/seniority-engine/snapshot.test.ts`
+   - `pnpm lint`
+   - `pnpm typecheck`
+   - `pnpm test`
+4. Prefer `pipe()` for linear data flows; avoid forcing Remeda when a simple loop is clearer.
+
+## First change completed in this branch
+
+- Added `remeda` dependency.
+- Migrated `uniqueEntryValues` in snapshot engine to a Remeda pipeline as the initial low-risk step.
+- Migrated duplicate-validation flow in `collectDuplicateIssues` to grouped Remeda pipelines.
+- Migrated `upcomingRetirements` in lens to a Remeda pipeline (`filter -> sortBy -> map`).

--- a/package.json
+++ b/package.json
@@ -39,6 +39,7 @@
     "nuxt": "^4.0.0",
     "pinia": "^3.0.4",
     "reka-ui": "^2.8.2",
+    "remeda": "^2.33.7",
     "tailwindcss": "^4.0.0",
     "vue-chartjs": "^5.3.3",
     "xlsx": "^0.18.5",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -59,6 +59,9 @@ importers:
       reka-ui:
         specifier: ^2.8.2
         version: 2.8.2(vue@3.5.29(typescript@5.9.3))
+      remeda:
+        specifier: ^2.33.7
+        version: 2.33.7
       tailwindcss:
         specifier: ^4.0.0
         version: 4.2.1
@@ -6192,6 +6195,9 @@ packages:
 
   remark-stringify@11.0.0:
     resolution: {integrity: sha512-1OSmLd3awB/t8qdoEOMazZkNsfVTeY4fTsgzcQFdXNq8ToTN4ZGwrMnlda4K6smTFKD+GRV6O48i6Z4iKgPPpw==}
+
+  remeda@2.33.7:
+    resolution: {integrity: sha512-cXlyjevWx5AcslOUEETG4o8XYi9UkoCXcJmj7XhPFVbla+ITuOBxv6ijBrmbeg+ZhzmDThkNdO+iXKUfrJep1w==}
 
   require-directory@2.1.1:
     resolution: {integrity: sha512-fGxEI7+wsG9xrvdjsrlmL22OMTTiHRwAMroiEeMgq8gzoLC/PQr7RsRDSTLUg/bZAZtF+TVIkHc6/4RIKrui+Q==}
@@ -14707,6 +14713,8 @@ snapshots:
       '@types/mdast': 4.0.4
       mdast-util-to-markdown: 2.1.2
       unified: 11.0.5
+
+  remeda@2.33.7: {}
 
   require-directory@2.1.1: {}
 


### PR DESCRIPTION
### Motivation

- Improve readability and consistency of data-shaping code in the seniority core by adopting Remeda-style pipeline helpers for linear transforms.
- Reduce imperative loop complexity in snapshot validation and value extraction while preserving public shapes and error messages.

### Description

- Added `remeda` as a dependency and updated lockfiles to include the package.
- Rewrote `collectDuplicateIssues` in `app/utils/seniority-engine/snapshot.ts` as a Remeda pipeline that groups entries and produces the same `SnapshotValidationIssue` output for duplicate seniority and employee numbers.  
- Reimplemented `uniqueEntryValues` in `snapshot.ts` using a Remeda pipeline of `map`, `filter`, `unique`, and `sort` to produce the same sorted list of values.  
- Refactored `upcomingRetirements` in `app/utils/seniority-engine/lens.ts` to use `pipe -> filter -> sortBy -> map` from Remeda (imported as `rPipe`, `rFilter`, `rSortBy`, `rMap`) while preserving the original result shape and ordering.  
- Added `docs/remeda-seniority-core-migration.md` outlining the incremental migration plan and noting the initial changes made in this branch.

### Testing

- Ran lint and type checks via `pnpm lint` and `pnpm typecheck`, both of which completed successfully.  
- Executed targeted unit tests for the snapshot utilities with `pnpm test app/utils/seniority-engine/snapshot.test.ts`, which passed.  
- Ran the full test suite with `pnpm test`, which completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69eed127c9188322a651e4692700a80f)