### PR TITLE
refactor: improve company overview aggregation readability with remeda pipes

### DIFF
--- a/app/composables/seniority/modules/useCompanyOverview.test.ts
+++ b/app/composables/seniority/modules/useCompanyOverview.test.ts
@@ -50,6 +50,26 @@ describe('useCompanyOverview', () => {
     expect(laxGroup.avgSeniority).toBe(3)
   })
 
+
+  it('ignores incomplete fleet/base entries and reports zero years when retire dates are missing', () => {
+    mockStore.entries = [
+      makeEntry({ seniority_number: 10, employee_number: 'E10', base: 'JFK', fleet: '737', retire_date: undefined }),
+      makeEntry({ seniority_number: 20, employee_number: 'E20', base: 'JFK', fleet: '737', retire_date: undefined }),
+      makeEntry({ seniority_number: 30, employee_number: 'E30', base: undefined, fleet: '737' }),
+      makeEntry({ seniority_number: 40, employee_number: 'E40', base: 'JFK', fleet: undefined }),
+    ]
+
+    const { aggregateStats } = useCompanyOverview()
+    expect(aggregateStats.value).toEqual([
+      {
+        category: '737 / JFK',
+        avgSeniority: 15,
+        avgYearsToRetire: 0,
+        totalPilots: 2,
+      },
+    ])
+  })
+
   it('formats recentLists from store lists', () => {
     mockStore.lists = [
       { id: 1, title: null, effectiveDate: '2026-01-15', createdAt: '2026-01-15T00:00:00Z' },

--- a/app/composables/seniority/modules/useCompanyOverview.ts
+++ b/app/composables/seniority/modules/useCompanyOverview.ts
@@ -1,4 +1,5 @@
 import type { ComputedRef } from 'vue'
+import { groupBy, map, pipe } from 'remeda'
 import type { SeniorityEntry } from '~/utils/schemas/seniority-list'
 import type { Qual } from '~/utils/seniority-engine'
 import { diffYears, formatMonthYear, todayISO } from '~/utils/date'
@@ -20,6 +21,38 @@ export interface RecentList {
   date: string
 }
 
+function toFleetBaseKey(entry: SeniorityEntry): string | undefined {
+  if (!entry.fleet || !entry.base) return undefined
+  return `${entry.fleet} / ${entry.base}`
+}
+
+function roundTenth(value: number): number {
+  return Math.round(value * 10) / 10
+}
+
+function calcAvgYearsToRetire(entries: SeniorityEntry[], now: string): number {
+  const entriesWithRetireDate = entries.filter(entry => !!entry.retire_date)
+  if (entriesWithRetireDate.length === 0) return 0
+
+  const totalYears = entriesWithRetireDate.reduce(
+    (sum, entry) => sum + diffYears(now, entry.retire_date!),
+    0,
+  )
+  return totalYears / entriesWithRetireDate.length
+}
+
+function toFleetBaseGroup(category: string, entries: SeniorityEntry[], now: string): FleetBaseGroup {
+  const totalPilots = entries.length
+  const avgSeniority = entries.reduce((sum, entry) => sum + entry.seniority_number, 0) / totalPilots
+
+  return {
+    category,
+    avgSeniority: roundTenth(avgSeniority),
+    avgYearsToRetire: roundTenth(calcAvgYearsToRetire(entries, now)),
+    totalPilots,
+  }
+}
+
 export function useCompanyOverview(): {
   aggregateStats: ComputedRef<FleetBaseGroup[]>
   recentLists: ComputedRef<RecentList[]>
@@ -29,38 +62,14 @@ export function useCompanyOverview(): {
   const { snapshot } = useSeniorityCore()
 
   const aggregateStats = computed<FleetBaseGroup[]>(() => {
-    const entries = seniorityStore.entries
-    const groups = new Map<string, SeniorityEntry[]>()
-
-    for (const e of entries) {
-      if (!e.fleet || !e.base) continue
-      const key = `${e.fleet} / ${e.base}`
-      if (!groups.has(key)) {
-        groups.set(key, [])
-      }
-      groups.get(key)!.push(e)
-    }
-
     const now = todayISO()
 
-    return Array.from(groups.entries()).map(([category, groupEntries]) => {
-      const totalPilots = groupEntries.length
-      const avgSeniority = groupEntries.reduce((sum, e) => sum + e.seniority_number, 0) / totalPilots
-
-      const entriesWithRetireDate = groupEntries.filter(e => e.retire_date)
-      const avgYearsToRetire = entriesWithRetireDate.length > 0
-        ? entriesWithRetireDate.reduce((sum, e) => {
-            return sum + diffYears(now, e.retire_date!)
-          }, 0) / entriesWithRetireDate.length
-        : 0
-
-      return {
-        category,
-        avgSeniority: Math.round(avgSeniority * 10) / 10,
-        avgYearsToRetire: Math.round(avgYearsToRetire * 10) / 10,
-        totalPilots,
-      }
-    })
+    return pipe(
+      seniorityStore.entries,
+      groupBy(toFleetBaseKey),
+      Object.entries,
+      map(([category, entries]) => toFleetBaseGroup(category, entries, now)),
+    )
   })
 
   const recentLists = computed<RecentList[]>(() => {


### PR DESCRIPTION
### Motivation
- Replace a handwritten grouping loop and nested reductions with a clearer functional pipeline to improve readability and debugging of the company-aggregation logic.
- Provide small, named helper functions instead of inline logic so each step in the data transformation is easier to understand and test.
- Ensure behavior is unchanged while making the data flow explicit and easier to maintain.

### Description
- Replaced manual grouping and aggregation in `useCompanyOverview` with a short Remeda pipeline using `groupBy` + `Object.entries` + `map` for the aggregate stats flow (`app/composables/seniority/modules/useCompanyOverview.ts`).
- Added focused helper functions: `toFleetBaseKey`, `roundTenth`, `calcAvgYearsToRetire`, and `toFleetBaseGroup` to encapsulate grouping key derivation, rounding, and retirement averaging.
- Added a unit test covering the edge case where entries lack `fleet`/`base` and where retire dates are missing to assert `avgYearsToRetire` becomes `0` (`app/composables/seniority/modules/useCompanyOverview.test.ts`).
- Preserved existing outputs and shapes so callers and UI remain unchanged.

### Testing
- Ran `pnpm vitest app/composables/seniority/modules/useCompanyOverview.test.ts` and the file-level tests passed.
- Ran the full suite with `pnpm test` and all tests passed (`78` files, `786` tests reported in this run).
- Ran `pnpm lint` and `pnpm typecheck` and both succeeded with zero errors.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f1f856ad5c832287288cc70bfcb3be)